### PR TITLE
Add support for shared services Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
   stages {
     stage('Checkout gh-pages') {
       steps {
-        dir ('/tmp/code/$BUILD_TAG') {
+        dir ("/tmp/code/${env.BUILD_TAG}") {
           sshagent (credentials: ['GITHUB_CI']) {
             sh '''
               git fetch --no-tags --progress git@github.com:intellihr/ui-components.git \
@@ -30,7 +30,7 @@ pipeline {
 
     stage('Build') {
       steps {
-        dir ('/tmp/code/$BUILD_TAG') {
+        dir ("/tmp/code/${env.BUILD_TAG}") {
           sh 'yarn build'
         }
       }
@@ -42,7 +42,7 @@ pipeline {
       }
 
       steps {
-        dir ('/tmp/code/$BUILD_TAG') {
+        dir ("/tmp/code/${env.BUILD_TAG}") {
           sshagent (credentials: ['GITHUB_CI']) {
             script {
               try {
@@ -64,7 +64,7 @@ pipeline {
       }
 
       steps {
-        dir ('/tmp/code/$BUILD_TAG') {
+        dir ("/tmp/code/${env.BUILD_TAG}") {
           sshagent (credentials: ['GITHUB_CI']) {
             sh 'git config user.email "continuous.integration@intellihr.com.au"'
             sh 'git config user.name "IntelliHR CI"'
@@ -97,7 +97,7 @@ pipeline {
   }
   post {
     always {
-      dir ('/tmp/code/$BUILD_TAG') {
+      dir ("/tmp/code/${env.BUILD_TAG}") {
         deleteDir()
       }
     }

--- a/Jenkinsfile-new
+++ b/Jenkinsfile-new
@@ -15,7 +15,7 @@ pipeline {
   stages {
     stage('Checkout gh-pages') {
       steps {
-        dir ('/tmp/code/$BUILD_TAG') {
+        dir ("/tmp/code/${env.BUILD_TAG}") {
           sshagent (credentials: ['GITHUB_CI_SSH_KEY']) {
             sh '''
               git fetch --no-tags --progress git@github.com:intellihr/ui-components.git \
@@ -28,7 +28,7 @@ pipeline {
 
     stage('Build') {
       steps {
-        dir ('/tmp/code/$BUILD_TAG') {
+        dir ("/tmp/code/${env.BUILD_TAG}") {
           sh 'yarn build'
         }
       }
@@ -40,7 +40,7 @@ pipeline {
       }
 
       steps {
-        dir ('/tmp/code/$BUILD_TAG') {
+        dir ("/tmp/code/${env.BUILD_TAG}") {
           sshagent (credentials: ['GITHUB_CI_SSH_KEY']) {
             script {
               try {
@@ -62,7 +62,7 @@ pipeline {
       }
 
       steps {
-        dir ('/tmp/code/$BUILD_TAG') {
+        dir ("/tmp/code/${env.BUILD_TAG}") {
           sshagent (credentials: ['GITHUB_CI_SSH_KEY']) {
             sh 'git config user.email "$GIT_EMAIL"'
             sh 'git config user.name "$GIT_USER"'
@@ -95,7 +95,7 @@ pipeline {
   }
   post {
     always {
-      dir ('/tmp/code/$BUILD_TAG') {
+      dir ("/tmp/code/${env.BUILD_TAG}") {
         deleteDir()
       }
     }


### PR DESCRIPTION
Only changes are:

- Use variables for some git commands so they don't need to be typed twice
- Rename SSH agent key because it has changed name in shared services jenkins to be more clear exactly what it is
- Remove helper definition because it isn't used
- Don't use /code to build. Use a folder in /tmp instead.