### PR TITLE
[INT-3654] Add color support to CurrencyText.

### DIFF
--- a/src/domain/Typographies/CurrencyText/CurrencyText.examples.md
+++ b/src/domain/Typographies/CurrencyText/CurrencyText.examples.md
@@ -17,7 +17,7 @@
     value={1000.499}
     prefix='AUD'
     prefixColor={Variables.Color.g400}
-    color={Variables.Color.r400}
+    valueColor={Variables.Color.r400}
     decimalPlace={2}
    />
 ```
@@ -30,21 +30,21 @@
       value={1000}
       prefix='AUD'
       prefixType='xsmall'
-      type='heading'
+      valueType='heading'
     />
     <br/>
     <CurrencyText
       value={1000}
       prefix='AUD'
       prefixType='body'
-      type='xsmall'
+      valueType='xsmall'
     />
     <br/>
     <CurrencyText
       value={1000}
       prefix='AUD'
       prefixType='display-large'
-      type='display'
+      valueType='display'
     />
   </div>
 ```
@@ -57,7 +57,7 @@
       value={1000}
       prefix='AUD'
       prefixType='xsmall'
-      type='heading'
+      valueType='heading'
       flexAlign
     />
     <br/>
@@ -65,7 +65,7 @@
       value={1000}
       prefix='AUD'
       prefixType='body'
-      type='xsmall'
+      valueType='xsmall'
       flexAlign
     />
     <br/>
@@ -73,7 +73,7 @@
       value={1000}
       prefix='AUD'
       prefixType='display-large'
-      type='display'
+      valueType='display'
       flexAlign
     />
   </div>

--- a/src/domain/Typographies/CurrencyText/CurrencyText.test.tsx
+++ b/src/domain/Typographies/CurrencyText/CurrencyText.test.tsx
@@ -34,7 +34,7 @@ describe('<CurrencyText />', () => {
       <CurrencyText
         value={1000}
         prefix='AUD'
-        color={Variables.Color.r200}
+        valueColor={Variables.Color.r200}
       />
     )
 
@@ -58,7 +58,7 @@ describe('<CurrencyText />', () => {
       <CurrencyText
         value={1000}
         prefix='AUD'
-        type={Props.TypographyType.XSmall}
+        valueType={Props.TypographyType.XSmall}
       />
     )
 
@@ -70,7 +70,7 @@ describe('<CurrencyText />', () => {
       <CurrencyText
         value={1000}
         prefix='AUD'
-        type={Props.TypographyType.XSmall}
+        valueType={Props.TypographyType.XSmall}
         prefixType={Props.TypographyType.Heading}
         flexAlign
       />

--- a/src/domain/Typographies/CurrencyText/CurrencyText.tsx
+++ b/src/domain/Typographies/CurrencyText/CurrencyText.tsx
@@ -9,7 +9,7 @@ interface ICurrencyTextProps {
   /** Monetary value to display */
   value?: string | number
   /** Monetary value text type  */
-  type?: Props.TypographyType
+  valueType?: Props.TypographyType
   /** Currency prefix to display */
   prefix?: string
   /** Currency prefix text type  */
@@ -20,14 +20,14 @@ interface ICurrencyTextProps {
   flexAlign?: boolean
   valueHint?: string
   /** Monetary value text color */
-  color?: Variables.Color
+  valueColor?: Variables.Color
   /** Currency prefix text color  */
   prefixColor?: Variables.Color
 }
 
 class CurrencyText extends React.PureComponent<ICurrencyTextProps> {
   public static defaultProps: Partial<ICurrencyTextProps> = {
-    type: Props.TypographyType.Body,
+    valueType: Props.TypographyType.Body,
     prefixType: Props.TypographyType.Body,
     decimalPlace:  0,
     flexAlign: false
@@ -59,8 +59,8 @@ class CurrencyText extends React.PureComponent<ICurrencyTextProps> {
     const {
       decimalPlace,
       value,
-      type,
-      color,
+      valueType,
+      valueColor,
       valueHint
     } = this.props
 
@@ -71,8 +71,8 @@ class CurrencyText extends React.PureComponent<ICurrencyTextProps> {
 
     return (
       <Text
-        type={type}
-        color={color}
+        type={valueType}
+        color={valueColor}
         hint={valueHint}
       >
         {Numeral(value!.toString()).format(moneyFormat)}

--- a/src/domain/Typographies/CurrencyText/__snapshots__/CurrencyText.test.tsx.snap
+++ b/src/domain/Typographies/CurrencyText/__snapshots__/CurrencyText.test.tsx.snap
@@ -32,8 +32,8 @@ exports[`<CurrencyText /> should render the Currency Text 1`] = `
   flexAlign={false}
   prefix="AUD"
   prefixType="body"
-  type="body"
   value={1000.499}
+  valueType="body"
 >
   <styled.span
     flexAlign={false}
@@ -123,8 +123,8 @@ exports[`<CurrencyText /> should render the Currency Text with 0 as value 1`] = 
   flexAlign={false}
   prefix="AUD"
   prefixType="body"
-  type="body"
   value={0}
+  valueType="body"
 >
   <styled.span
     flexAlign={false}
@@ -225,8 +225,8 @@ exports[`<CurrencyText /> should render the Currency Text with a center flex ali
   flexAlign={true}
   prefix="AUD"
   prefixType="heading"
-  type="xsmall"
   value={1000}
+  valueType="xsmall"
 >
   <styled.span
     flexAlign={true}
@@ -312,13 +312,13 @@ exports[`<CurrencyText /> should render the Currency Text with a red money color
 }
 
 <CurrencyText
-  color="#FFD2CC"
   decimalPlace={0}
   flexAlign={false}
   prefix="AUD"
   prefixType="body"
-  type="body"
   value={1000}
+  valueColor="#FFD2CC"
+  valueType="body"
 >
   <styled.span
     flexAlign={false}
@@ -412,8 +412,8 @@ exports[`<CurrencyText /> should render the Currency Text with a red prefix colo
   prefix="AUD"
   prefixColor="#FFD2CC"
   prefixType="body"
-  type="body"
   value={1000}
+  valueType="body"
 >
   <styled.span
     flexAlign={false}
@@ -507,8 +507,8 @@ exports[`<CurrencyText /> should render the Currency Text with an extra small mo
   flexAlign={false}
   prefix="AUD"
   prefixType="body"
-  type="xsmall"
   value={1000}
+  valueType="xsmall"
 >
   <styled.span
     flexAlign={false}
@@ -598,8 +598,8 @@ exports[`<CurrencyText /> should render the Currency Text with an extra small pr
   flexAlign={false}
   prefix="AUD"
   prefixType="xsmall"
-  type="body"
   value={1000}
+  valueType="body"
 >
   <styled.span
     flexAlign={false}
@@ -662,7 +662,7 @@ exports[`<CurrencyText /> should render the Currency Text without value 1`] = `
   decimalPlace={0}
   flexAlign={false}
   prefixType="body"
-  type="body"
+  valueType="body"
 >
   -
 </CurrencyText>


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [x]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [x]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
