### PR TITLE
[INT-3508] Fix input group overflow on firefox

### DIFF
--- a/src/domain/Inputs/InputGroup/style.ts
+++ b/src/domain/Inputs/InputGroup/style.ts
@@ -3,6 +3,11 @@ import styled from 'styled-components'
 
 const InputGroupWrapper = styled.div`
   display: flex;
+  
+  input {
+    width: 0;
+    flex: 1 1 auto;
+  }
 `
 
 export {


### PR DESCRIPTION
INT-3508

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
