### PR TITLE
[INT-3799] Add missing keyboard focus styling to autocomplete address.

### DIFF
--- a/src/domain/Inputs/AutocompleteLocationInput/style.scss
+++ b/src/domain/Inputs/AutocompleteLocationInput/style.scss
@@ -42,7 +42,8 @@
       text-overflow: ellipsis;
       white-space: nowrap;
 
-      &:hover {
+      &:hover,
+      &.geosuggest__item--active {
         background-color: $n200;
       }
     }


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
