### PR TITLE
[INT-4678] Move HintWrapper type enum to props

### DIFF
--- a/src/common/types/props.ts
+++ b/src/common/types/props.ts
@@ -68,6 +68,11 @@ namespace Props {
     Vertical = 'vertical',
     Horizontal = 'horizontal'
   }
+
+  export enum HintWrapperType {
+    Popover = 'popover',
+    Tooltip = 'tooltip'
+  }
 }
 
 export {

--- a/src/domain/Formats/HintWrapper/HintWrapper.test.tsx
+++ b/src/domain/Formats/HintWrapper/HintWrapper.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import { HintWrapper, HintWrapperType } from './HintWrapper'
+import { Props } from '../../../common'
+import { HintWrapper } from './HintWrapper'
 import { Brick } from '../../Typographies/Brick'
 
 describe('<HintWrapper />', () => {
@@ -34,7 +35,7 @@ describe('<HintWrapper />', () => {
     const wrapper = shallow(
       <HintWrapper
         hint='Never trust a cat'
-        hintType={HintWrapperType.Popover}
+        hintType={Props.HintWrapperType.Popover}
       >
         Hover me for a tip :)
       </HintWrapper>

--- a/src/domain/Formats/HintWrapper/HintWrapper.tsx
+++ b/src/domain/Formats/HintWrapper/HintWrapper.tsx
@@ -4,16 +4,11 @@ import { StyledHintWrapper } from './style'
 import { Tooltip } from '../../Tooltips/Tooltip'
 import { TooltipPopover, ITooltipPopoverToggleComponentProps } from '../../Popovers/TooltipPopover'
 
-enum HintWrapperType {
-  Popover = 'popover',
-  Tooltip = 'tooltip'
-}
-
 interface IHintWrapperProps {
   /** The hint text to display on hover */
   hint: JSX.Element | string
   /** The hint type to display on hover */
-  hintType?: HintWrapperType
+  hintType?: Props.HintWrapperType
   /** The width of the hint object */
   width?: number
   /** The data-component-context */
@@ -22,7 +17,7 @@ interface IHintWrapperProps {
 
 class HintWrapper extends React.PureComponent<IHintWrapperProps> {
   public static defaultProps: Partial<IHintWrapperProps> = {
-    hintType: HintWrapperType.Tooltip
+    hintType: Props.HintWrapperType.Tooltip
   }
 
   public render (): JSX.Element {
@@ -39,7 +34,7 @@ class HintWrapper extends React.PureComponent<IHintWrapperProps> {
       'data-component-context': componentContext
     }
 
-    if (hintType === HintWrapperType.Popover) {
+    if (hintType === Props.HintWrapperType.Popover) {
       return (
         <TooltipPopover
           toggleComponent={this.popoverToggle}
@@ -91,6 +86,5 @@ class HintWrapper extends React.PureComponent<IHintWrapperProps> {
 
 export {
   HintWrapper,
-  HintWrapperType,
   IHintWrapperProps
 }

--- a/src/domain/Formats/HintWrapper/index.ts
+++ b/src/domain/Formats/HintWrapper/index.ts
@@ -1,5 +1,4 @@
 export {
   HintWrapper,
-  HintWrapperType,
   IHintWrapperProps
 } from './HintWrapper'

--- a/src/domain/Typographies/CurrencyText/CurrencyText.examples.md
+++ b/src/domain/Typographies/CurrencyText/CurrencyText.examples.md
@@ -11,13 +11,15 @@
 #### Currency Text With A Value Hint
 
 ```jsx
+  const { Props } = require('@Common');
+
   <CurrencyText
     value={1000.499}
     prefix='AUD'
     decimalPlace={2}
     valueHintComponentProps={{
       hint: 'Some hint regarding the currency value',
-      hintType: 'popover',
+      hintType: Props.HintWrapperType.Popover,
       width: 250
     }}
    />

--- a/src/domain/Typographies/Text/Text.examples.md
+++ b/src/domain/Typographies/Text/Text.examples.md
@@ -132,10 +132,12 @@ const { Variables } = require('../../../common');
 
 #### Hint (Popover)
 ```jsx
+  const { Props } = require('@Common');
+
   <Text
     hintComponentProps={{
       hint: 'I can be a string or a JSX Element!',
-      hintType: 'popover'
+      hintType: Props.HintWrapperType.Popover
     }}
   >
     Hover me

--- a/src/domain/Typographies/Text/Text.test.tsx
+++ b/src/domain/Typographies/Text/Text.test.tsx
@@ -3,7 +3,6 @@ import { mount } from 'enzyme'
 
 import { Text } from './Text'
 import { Variables, Props } from '../../../common'
-import { HintWrapperType } from '../../Formats/HintWrapper'
 
 describe('<Text />', () => {
   it(`should render an element with text`, () => {
@@ -90,7 +89,7 @@ describe('<Text />', () => {
       <Text
         hintComponentProps={{
           hint: 'Test',
-          hintType: HintWrapperType.Popover
+          hintType: Props.HintWrapperType.Popover
         }}
       >
         Hello! I am text with a hint
@@ -106,7 +105,7 @@ describe('<Text />', () => {
       <Text
         hintComponentProps={{
           hint: 'Test',
-          hintType: HintWrapperType.Tooltip
+          hintType: Props.HintWrapperType.Tooltip
       }}
       >
         Hello! I am text with a hint


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [x]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
