### PR TITLE
[INT-4619] Add optional prop to underline TextLink on hover

### DIFF
--- a/src/domain/Links/TextLink/TextLink.examples.md
+++ b/src/domain/Links/TextLink/TextLink.examples.md
@@ -44,6 +44,13 @@
     Display Large Link
   </TextLink>
   <br />
+</div>
+```
+
+#### Inline (false)
+
+```jsx
+<div>
   <TextLink
     textType='body'
     isInline={false}
@@ -57,6 +64,16 @@
     Block TextLink 2
   </TextLink>
 </div>
+```
+
+#### Underline on hover
+```jsx
+  <TextLink
+    href='#'
+    underlineOnHover
+  >
+    I'm underlined when you hover over me!
+  </TextLink>
 ```
 
 #### Using a default component

--- a/src/domain/Links/TextLink/TextLink.test.tsx
+++ b/src/domain/Links/TextLink/TextLink.test.tsx
@@ -26,4 +26,17 @@ describe('<TextLink />', () => {
 
     expect(wrapper).toMatchSnapshot()
   })
+
+  it('should render a text link with underline on hover', () => {
+    const wrapper = mount(
+      <TextLink
+        href='#'
+        underlineOnHover
+      >
+        Underline text link on hover
+      </TextLink>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
 })

--- a/src/domain/Links/TextLink/TextLink.tsx
+++ b/src/domain/Links/TextLink/TextLink.tsx
@@ -8,6 +8,7 @@ import { styleForTypographyType } from '../../Typographies/services/textStyles'
 interface ITextLinkProps extends IAnchorProps {
   textType?: Props.TypographyType
   isInline?: boolean
+  underlineOnHover?: boolean
 }
 
 const styledAnchor: StyledFunction<ITextLinkProps> = styled(({ textType, isInline, ...rest }) => <Anchor {...rest} />)
@@ -31,6 +32,15 @@ const StyledTextLink = styledAnchor`
 
   &:hover {
     color: ${Variables.Color.i500};
+    ${
+      ({ underlineOnHover }: ITextLinkProps) => {
+        if (underlineOnHover) {
+          return css`
+            text-decoration: underline;
+          `
+        }
+      }
+    }
   }
 
   &:active {

--- a/src/domain/Links/TextLink/__snapshots__/TextLink.test.tsx.snap
+++ b/src/domain/Links/TextLink/__snapshots__/TextLink.test.tsx.snap
@@ -111,3 +111,66 @@ exports[`<TextLink /> should render a text link with display block 1`] = `
   </Styled(Component)>
 </TextLink>
 `;
+
+exports[`<TextLink /> should render a text link with underline on hover 1`] = `
+.c0 {
+  -webkit-transition: color .25s ease-out;
+  transition: color .25s ease-out;
+  font-size: 16px;
+  line-height: 24px;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  display: inline;
+}
+
+.c0,
+.c0:link,
+.c0:visited {
+  color: #432DF3;
+}
+
+.c0:hover {
+  color: #2512B3;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:active {
+  color: #0F0080;
+}
+
+<TextLink
+  href="#"
+  isInline={true}
+  underlineOnHover={true}
+>
+  <Styled(Component)
+    href="#"
+    isInline={true}
+    underlineOnHover={true}
+  >
+    <Component
+      className="c0"
+      href="#"
+      isInline={true}
+      underlineOnHover={true}
+    >
+      <Anchor
+        className="c0"
+        href="#"
+        underlineOnHover={true}
+      >
+        <a
+          className="c0"
+          href="#"
+          underlineOnHover={true}
+        >
+          Underline text link on hover
+        </a>
+      </Anchor>
+    </Component>
+  </Styled(Component)>
+</TextLink>
+`;


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [x]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [x]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
