### PR TITLE
[INT-4754] Standardize disabled input text colour

### DIFF
--- a/src/domain/Inputs/Input/Input.examples.md
+++ b/src/domain/Inputs/Input/Input.examples.md
@@ -138,5 +138,6 @@ import { TextInput } from '@Domain/Inputs';
 
 <TextInput
   isDisabled
+  value="Disabled input. Can't change this text"
 />
 ```

--- a/src/domain/Inputs/Input/style.scss
+++ b/src/domain/Inputs/Input/style.scss
@@ -1,4 +1,11 @@
+@import '../../../common/sass/variables';
+
 :local(.input) {
+  &:disabled,
+  &[disabled] {
+    color: $n600;
+  }
+
   &.input-group-left {
     border-radius: 4px 0 0 4px;
   }

--- a/src/domain/Inputs/SelectInput/SelectInput.examples.md
+++ b/src/domain/Inputs/SelectInput/SelectInput.examples.md
@@ -95,3 +95,23 @@ const simulateServerSideFiltering = (input) => new Promise((resolve, reject) => 
   asyncOptions={simulateServerSideFiltering}
 />
 ```
+
+#### Disabled Select Input
+
+```jsx
+<SelectInput
+  name='testInput'
+  value={20}
+  isDisabled
+  options={[
+    {
+      label: 'Hello World',
+      value: 20
+    },
+    {
+      label: 'Try selecting me',
+      value: 40
+    }
+  ]}
+/>
+```

--- a/src/domain/Inputs/SelectInput/style.scss
+++ b/src/domain/Inputs/SelectInput/style.scss
@@ -17,6 +17,12 @@
           background-color: $n200;
           cursor: not-allowed;
         }
+
+        .Select-value {
+          .Select-value-label {
+            color: $n600;
+          }
+        }
       }
     }
 

--- a/src/domain/Inputs/SingleDateInput/style.scss
+++ b/src/domain/Inputs/SingleDateInput/style.scss
@@ -74,6 +74,10 @@
     }
   }
 
+  .DateInput_input__disabled {
+    color: $n600;
+  }
+
   &.is-invalid-input {
     &:not(:focus) {
       background-color: transparent;

--- a/src/domain/Inputs/TextAreaInput/TextAreaInput.examples.md
+++ b/src/domain/Inputs/TextAreaInput/TextAreaInput.examples.md
@@ -11,6 +11,21 @@ initialState = { value: '' };
 </div>
 ```
 
+#### Disabled text area
+
+```jsx
+initialState = { value: '' };
+
+<div>
+  <TextAreaInput
+    value={state.value}
+    handleChange={(e) => setState({value: e.value})}
+    isDisabled
+    value="Text area is disabled so you can't change this text"
+  />
+</div>
+```
+
 #### Customize with props
 
 ```jsx

--- a/src/domain/Inputs/TextAreaInput/style.ts
+++ b/src/domain/Inputs/TextAreaInput/style.ts
@@ -2,9 +2,16 @@ import React from 'react'
 import AutosizeTextarea from 'react-autosize-textarea'
 import styled, { StyledComponentClass } from 'styled-components'
 
+import { Variables } from '../../../common'
+
 const StyledAutosizeTextarea = styled(AutosizeTextarea)`
   min-height: 39px;
   resize: none;
+
+  &:disabled,
+  &[disabled] {
+    color: ${Variables.Color.n600}
+  }
 `
 
 export {


### PR DESCRIPTION
INT-4754

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
