### PR TITLE
[INT-4937] Add context/type to Board and Tile

### DIFF
--- a/src/common/types/props.ts
+++ b/src/common/types/props.ts
@@ -43,6 +43,7 @@ namespace Props {
   export enum ComponentType {
     AvatarGroup = 'avatar_group',
     BlockTabGroup = 'block_tab_group',
+    Board = 'board',
     Breadcrumb = 'breadcrumb',
     BreadcrumbGroup = 'breadcrumb_group',
     Brick = 'brick',
@@ -61,6 +62,7 @@ namespace Props {
     Record = 'record',
     RecordName = 'record_name',
     Text = 'text',
+    Tile = 'tile',
     Timeline = 'timeline',
     TimelineEvent = 'timeline_event'
   }

--- a/src/domain/Boards/Board/Board.tsx
+++ b/src/domain/Boards/Board/Board.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 
-import { BoardWrapper, StyledBoardLabel} from './style'
+import { Props } from '../../../common'
+import { BoardTilesWrapper, BoardWrapper, StyledBoardLabel } from './style'
 import { Tile } from './subcomponents/Tile'
 
 interface IBoardProps {
   /** Text displayed above the board */
   label?: string
+  /** The data-component-context */
+  componentContext?: string
 }
 export class Board extends React.PureComponent<IBoardProps> {
   public static Tile = Tile
@@ -26,14 +29,18 @@ export class Board extends React.PureComponent<IBoardProps> {
 
   public render (): JSX.Element {
     const {
-      children
+      children,
+      componentContext
     } = this.props
 
     return (
-      <>
+      <BoardWrapper
+        data-component-type={Props.ComponentType.Board}
+        data-component-context={componentContext}
+      >
         {this.label}
-        <BoardWrapper> {children} </BoardWrapper>
-      </>
+        <BoardTilesWrapper> {children} </BoardTilesWrapper>
+      </BoardWrapper>
     )
   }
 }

--- a/src/domain/Boards/Board/__snapshots__/Board.test.tsx.snap
+++ b/src/domain/Boards/Board/__snapshots__/Board.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Board /> should render a board 1`] = `
-<Fragment>
+<styled.div
+  data-component-type="board"
+>
   <styled.label>
      
     Basic board
@@ -12,5 +14,5 @@ exports[`<Board /> should render a board 1`] = `
     Children
      
   </styled.div>
-</Fragment>
+</styled.div>
 `;

--- a/src/domain/Boards/Board/style.ts
+++ b/src/domain/Boards/Board/style.ts
@@ -2,7 +2,9 @@ import styled from 'styled-components'
 
 import { Variables } from '../../../common'
 
-const BoardWrapper = styled.div`
+const BoardWrapper = styled.div``
+
+const BoardTilesWrapper = styled.div`
   display: flex;
   align-content: stretch;
   flex-wrap: wrap;
@@ -20,5 +22,6 @@ const StyledBoardLabel = styled.label`
 
 export {
   StyledBoardLabel,
-  BoardWrapper
+  BoardWrapper,
+  BoardTilesWrapper
 }

--- a/src/domain/Boards/Board/subcomponents/Tile.tsx
+++ b/src/domain/Boards/Board/subcomponents/Tile.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { Props } from '../../../../common'
 import { StyleTileButton, StyledAnchorTile, StyledHoverLabel } from './style'
 import { ButtonTileContent } from './ButtonTileContent'
 import { CenteredTileContent } from './CenteredTileContent'
@@ -24,6 +25,8 @@ interface IBoardTileProps {
   anchorComponentProps?: {
     [i: string]: any
   }
+  /** The data-component-context */
+  componentContext?: string
 }
 
 class Tile extends React.PureComponent<IBoardTileProps, never> {
@@ -65,19 +68,26 @@ class Tile extends React.PureComponent<IBoardTileProps, never> {
       isButton,
       type,
       onClick,
-      hoverLabel
+      hoverLabel,
+      componentContext
     } = this.props
+
+    const commonProps = {
+      'tileSize': size!,
+      'isHoverable': isHoverable!,
+      onClick,
+      'tabIndex': 0,
+      'isButton': isButton!,
+      'type': type!,
+      'hasHoverLabel': !!hoverLabel,
+      'data-component-type': Props.ComponentType.Tile,
+      'data-component-context': componentContext
+    }
 
     if (anchorHref) {
       return (
         <StyledAnchorTile
-          tileSize={size!}
-          isHoverable={isHoverable!}
-          onClick={onClick}
-          tabIndex={0}
-          isButton={isButton!}
-          type={type!}
-          hasHoverLabel={!!hoverLabel}
+          {...commonProps}
           href={anchorHref}
           anchorComponentProps={anchorComponentProps}
         >
@@ -89,13 +99,7 @@ class Tile extends React.PureComponent<IBoardTileProps, never> {
 
     return (
       <StyleTileButton
-        tileSize={size!}
-        isHoverable={isHoverable!}
-        onClick={onClick}
-        tabIndex={0}
-        isButton={isButton!}
-        type={type!}
-        hasHoverLabel={!!hoverLabel}
+        {...commonProps}
       >
         {children}
         {this.hoverLabel}

--- a/src/domain/Boards/Board/subcomponents/__snapshots__/Tile.test.tsx.snap
+++ b/src/domain/Boards/Board/subcomponents/__snapshots__/Tile.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Tile /> should render a board tile with nothing 1`] = `
 <styled.div
+  data-component-type="tile"
   hasHoverLabel={false}
   isButton={false}
   isHoverable={true}
@@ -13,6 +14,7 @@ exports[`<Tile /> should render a board tile with nothing 1`] = `
 
 exports[`<Tile /> should render a hoverable board tile button in hollow style with hover label 1`] = `
 <styled.div
+  data-component-type="tile"
   hasHoverLabel={false}
   isButton={true}
   isHoverable={true}
@@ -24,6 +26,7 @@ exports[`<Tile /> should render a hoverable board tile button in hollow style wi
 
 exports[`<Tile /> should render a hoverable board tile button with hover label 1`] = `
 <styled.div
+  data-component-type="tile"
   hasHoverLabel={false}
   isButton={true}
   isHoverable={true}
@@ -35,6 +38,7 @@ exports[`<Tile /> should render a hoverable board tile button with hover label 1
 
 exports[`<Tile /> should render a hoverable board tile with hover label 1`] = `
 <styled.div
+  data-component-type="tile"
   hasHoverLabel={true}
   isButton={false}
   isHoverable={true}
@@ -50,6 +54,7 @@ exports[`<Tile /> should render a hoverable board tile with hover label 1`] = `
 
 exports[`<Tile /> should render a large board tile 1`] = `
 <styled.div
+  data-component-type="tile"
   hasHoverLabel={false}
   isButton={false}
   isHoverable={true}
@@ -61,6 +66,7 @@ exports[`<Tile /> should render a large board tile 1`] = `
 
 exports[`<Tile /> should render a medium board tile 1`] = `
 <styled.div
+  data-component-type="tile"
   hasHoverLabel={false}
   isButton={false}
   isHoverable={true}
@@ -72,6 +78,7 @@ exports[`<Tile /> should render a medium board tile 1`] = `
 
 exports[`<Tile /> should render a non-hoverable board tile 1`] = `
 <styled.div
+  data-component-type="tile"
   hasHoverLabel={false}
   isButton={false}
   isHoverable={false}
@@ -83,6 +90,7 @@ exports[`<Tile /> should render a non-hoverable board tile 1`] = `
 
 exports[`<Tile /> should render a small board tile 1`] = `
 <styled.div
+  data-component-type="tile"
   hasHoverLabel={false}
   isButton={false}
   isHoverable={true}
@@ -94,6 +102,7 @@ exports[`<Tile /> should render a small board tile 1`] = `
 
 exports[`<Tile /> should render an anchor board tile 1`] = `
 <Styled(Component)
+  data-component-type="tile"
   hasHoverLabel={false}
   href="#dummy"
   isButton={false}


### PR DESCRIPTION
INT-4937

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [x]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [x]  The component has data-component-type and data-component-context attributes following the standard
