### PR TITLE
[INT-5080] Add hint option to vertical form field

### DIFF
--- a/src/domain/Forms/VerticalForm/VerticalForm.examples.md
+++ b/src/domain/Forms/VerticalForm/VerticalForm.examples.md
@@ -185,6 +185,42 @@ initialState = { textInputValue: '' };
   </VerticalForm>
 ```
 
+Field with hint
+
+```jsx
+import { Button } from '@Domain/Buttons';
+import { TextInput } from '@Domain/Inputs';
+
+initialState = { textInputValue: '' };
+
+  <VerticalForm
+    onSubmit={() => alert(`Test input: ${state.textInputValue}`)}
+  >
+    <VerticalForm.Field
+      inputName='testInput'
+      hintOptions={{
+        hint: <div> This is a test hint in the hint popover style </div>,
+        label: 'This is a test hint label',
+        hintWrapperProps: { width: 200 }
+      }}
+      label='This is a test input'
+      isRequired
+    >
+      <TextInput
+        name='testInput'
+        handleChange={(e) => setState({ textInputValue: e.target.value })}
+      />
+    </VerticalForm.Field>
+    <VerticalForm.RightAlignControls>
+      <Button
+         type='primary'
+      >
+        Submit me :)
+      </Button>
+    </VerticalForm.RightAlignControls>
+  </VerticalForm>
+```
+
 Field with errors & required
 
 ```jsx

--- a/src/domain/Forms/VerticalForm/subcomponents/Field.test.tsx
+++ b/src/domain/Forms/VerticalForm/subcomponents/Field.test.tsx
@@ -85,6 +85,36 @@ describe('<Field />', () => {
     const wrapper = shallow(
       <Field
         label='This is a test input'
+        actionMessage={<div>This is a test action message</div>}
+      >
+        Children
+      </Field>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it(`should render a vertical form field with a hint`, () => {
+    const wrapper = shallow(
+      <Field
+        label='This is a test input'
+        hintOptions={{
+          hint: <div> This is a test hint in hint popover style </div>,
+          label: 'This is a test hint label',
+          hintWrapperProps: { width: 200 }
+        }}
+      >
+        Children
+      </Field>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it(`should render a vertical form field with a action message`, () => {
+    const wrapper = shallow(
+      <Field
+        label='This is a test input'
         tooltipMessage='I am a test tooltip'
         tooltipProps={{width: 100}}
       >

--- a/src/domain/Forms/VerticalForm/subcomponents/Field.tsx
+++ b/src/domain/Forms/VerticalForm/subcomponents/Field.tsx
@@ -1,8 +1,19 @@
 import { isString, map } from 'lodash'
 import React from 'react'
 
+import { Props } from '../../../../common'
+import { HintWrapper } from '../../../Formats'
+import { IHintWrapperProps } from '../../../Formats/HintWrapper'
 import { ITooltipPopoverProps, TooltipPopover } from '../../../Popovers/TooltipPopover'
-import { ErrorMessage, FieldWrapper, StyledDescription, StyledInputLabel, StyledTooltipPopover } from './style'
+import { Text } from '../../../Typographies/Text'
+import {
+  ErrorMessage,
+  FieldWrapper,
+  StyledDescription,
+  StyledInputLabel,
+  StyledLabelWrapper,
+  StyledTooltipPopover
+} from './style'
 
 interface IVerticalFormFieldProps {
   /** HTML name of the input */
@@ -21,7 +32,12 @@ interface IVerticalFormFieldProps {
   tooltipMessage?: JSX.Element | string
   /** any extra tooltip props */
   tooltipProps?: ITooltipPopoverProps
-
+  /** Popover hint after the label */
+  hintOptions?: {
+    hint: JSX.Element | string
+    label: string
+    hintWrapperProps?: Partial<IHintWrapperProps>
+  }
 }
 
 class Field extends React.PureComponent<IVerticalFormFieldProps, never> {
@@ -100,6 +116,37 @@ class Field extends React.PureComponent<IVerticalFormFieldProps, never> {
     return null
   }
 
+  private get hint (): JSX.Element | null {
+    const {
+      hintOptions
+    } = this.props
+
+    if (hintOptions) {
+      return (
+        <HintWrapper
+          hint={hintOptions.hint}
+          hintType={Props.HintWrapperType.Popover}
+          {...hintOptions.hintWrapperProps}
+        >
+          <Text type={Props.TypographyType.XSmall}>
+            {hintOptions.label}
+          </Text>
+        </HintWrapper>
+      )
+    }
+
+    return null
+  }
+
+  private get label (): JSX.Element {
+    return (
+      <StyledLabelWrapper>
+        {this.inputLabel}
+        {this.hint}
+      </StyledLabelWrapper>
+    )
+  }
+
   public static defaultProps = {
     isRequired: false
   }
@@ -112,7 +159,7 @@ class Field extends React.PureComponent<IVerticalFormFieldProps, never> {
 
     return (
       <FieldWrapper>
-        {this.inputLabel}
+        {this.label}
         {this.description}
         {children}
         {this.errorMessages}

--- a/src/domain/Forms/VerticalForm/subcomponents/__snapshots__/Field.test.tsx.snap
+++ b/src/domain/Forms/VerticalForm/subcomponents/__snapshots__/Field.test.tsx.snap
@@ -2,11 +2,13 @@
 
 exports[`<Field /> should render a vertical form field with a action message 1`] = `
 <styled.div>
-  <styled.label
-    isRequired={false}
-  >
-    This is a test input
-  </styled.label>
+  <styled.div>
+    <styled.label
+      isRequired={false}
+    >
+      This is a test input
+    </styled.label>
+  </styled.div>
   Children
   <div>
     This is a test action message
@@ -16,30 +18,50 @@ exports[`<Field /> should render a vertical form field with a action message 1`]
 
 exports[`<Field /> should render a vertical form field with a action message 2`] = `
 <styled.div>
-  <styled.label
-    isRequired={false}
-  >
-    This is a test input
-    <styled.span>
-      <TooltipPopover
-        toggleComponent={[Function]}
-        width={100}
-      >
-        I am a test tooltip
-      </TooltipPopover>
-    </styled.span>
-  </styled.label>
+  <styled.div>
+    <styled.label
+      isRequired={false}
+    >
+      This is a test input
+    </styled.label>
+  </styled.div>
+  Children
+  <div>
+    This is a test action message
+  </div>
+</styled.div>
+`;
+
+exports[`<Field /> should render a vertical form field with a action message 3`] = `
+<styled.div>
+  <styled.div>
+    <styled.label
+      isRequired={false}
+    >
+      This is a test input
+      <styled.span>
+        <TooltipPopover
+          toggleComponent={[Function]}
+          width={100}
+        >
+          I am a test tooltip
+        </TooltipPopover>
+      </styled.span>
+    </styled.label>
+  </styled.div>
   Children
 </styled.div>
 `;
 
 exports[`<Field /> should render a vertical form field with a description 1`] = `
 <styled.div>
-  <styled.label
-    isRequired={false}
-  >
-    This is a test input
-  </styled.label>
+  <styled.div>
+    <styled.label
+      isRequired={false}
+    >
+      This is a test input
+    </styled.label>
+  </styled.div>
   <styled.div>
     This is a test description
   </styled.div>
@@ -47,13 +69,45 @@ exports[`<Field /> should render a vertical form field with a description 1`] = 
 </styled.div>
 `;
 
+exports[`<Field /> should render a vertical form field with a hint 1`] = `
+<styled.div>
+  <styled.div>
+    <styled.label
+      isRequired={false}
+    >
+      This is a test input
+    </styled.label>
+    <HintWrapper
+      hint={
+        <div>
+           This is a test hint in hint popover style 
+        </div>
+      }
+      hintType="popover"
+      width={200}
+    >
+      <Text
+        isInline={true}
+        tag="span"
+        type="xsmall"
+      >
+        This is a test hint label
+      </Text>
+    </HintWrapper>
+  </styled.div>
+  Children
+</styled.div>
+`;
+
 exports[`<Field /> should render a vertical form field with a single error message 1`] = `
 <styled.div>
-  <styled.label
-    isRequired={false}
-  >
-    This is a test input
-  </styled.label>
+  <styled.div>
+    <styled.label
+      isRequired={false}
+    >
+      This is a test input
+    </styled.label>
+  </styled.div>
   Children
   <styled.div>
     Just one error
@@ -63,11 +117,13 @@ exports[`<Field /> should render a vertical form field with a single error messa
 
 exports[`<Field /> should render a vertical form field with error messages 1`] = `
 <styled.div>
-  <styled.label
-    isRequired={false}
-  >
-    This is a test input
-  </styled.label>
+  <styled.div>
+    <styled.label
+      isRequired={false}
+    >
+      This is a test input
+    </styled.label>
+  </styled.div>
   Children
   <styled.div>
     Error 1
@@ -80,16 +136,22 @@ exports[`<Field /> should render a vertical form field with error messages 1`] =
 </styled.div>
 `;
 
-exports[`<Field /> should render a vertical form field with nothing 1`] = `<styled.div />`;
+exports[`<Field /> should render a vertical form field with nothing 1`] = `
+<styled.div>
+  <styled.div />
+</styled.div>
+`;
 
 exports[`<Field /> should render a vertical form field with regular props 1`] = `
 <styled.div>
-  <styled.label
-    htmlFor="testInput"
-    isRequired={true}
-  >
-    This is a test input
-  </styled.label>
+  <styled.div>
+    <styled.label
+      htmlFor="testInput"
+      isRequired={true}
+    >
+      This is a test input
+    </styled.label>
+  </styled.div>
   Children
 </styled.div>
 `;

--- a/src/domain/Forms/VerticalForm/subcomponents/style.ts
+++ b/src/domain/Forms/VerticalForm/subcomponents/style.ts
@@ -1,7 +1,6 @@
 import styled, { css } from 'styled-components'
 
-import { Variables } from '../../../../common'
-import { TooltipPopover } from '../../../Popovers/TooltipPopover'
+import { Utils, Variables } from '../../../../common'
 
 interface IStyledInputLabelProps {
   isRequired: boolean
@@ -29,6 +28,11 @@ const StyledInputLabel = styled.label`
   font-size: ${Variables.FontSize.fzSmall}px;
   line-height: ${Variables.LineHeight.lhSmall}px;
   margin-bottom: 4px;
+  display: block;
+
+  ${Utils.mediaQueryBetweenSizes({ maxPx: Variables.Breakpoint.breakpointTablet })} {
+    width: 100%;
+  }
 
   ${(props: IStyledInputLabelProps) => props.isRequired && css`
       &::after {
@@ -57,6 +61,16 @@ const StyledRightAlignControls = styled.div`
   justify-content: flex-end;
 `
 
+const StyledLabelWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+
+  ${Utils.mediaQueryBetweenSizes({ maxPx: Variables.Breakpoint.breakpointTablet })} {
+    flex-wrap: wrap;
+    margin-bottom: ${Variables.Spacing.s2XSmall}px;
+  }
+`
 export {
   FieldWrapper,
   ErrorMessage,
@@ -64,5 +78,6 @@ export {
   StyledDescription,
   StyledTooltipPopover,
   StyledLeftAlignControls,
-  StyledRightAlignControls
+  StyledRightAlignControls,
+  StyledLabelWrapper
 }


### PR DESCRIPTION
INT-5080

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
