### PR TITLE
[INT-5128] Make text link buttons default to type button instead of submit.

### DIFF
--- a/src/domain/Links/TextLink/TextLink.tsx
+++ b/src/domain/Links/TextLink/TextLink.tsx
@@ -28,10 +28,10 @@ const TextLinkStyles = css`
   transition: color .25s ease-out;
   cursor: pointer;
 
-  ${(props: ITextLinkProps) => styleForTypographyType(props.textType)}
+  ${(props: ITextLinkCommonProps) => styleForTypographyType(props.textType)}
 
   ${
-    ({isInline}: ITextLinkProps) => css`
+    ({isInline}: ITextLinkCommonProps) => css`
       display: ${isInline && 'inline' || 'block'};
     `
   }
@@ -45,7 +45,7 @@ const TextLinkStyles = css`
   &:hover {
     color: ${Variables.Color.i500};
     ${
-      ({underlineOnHover}: ITextLinkProps) => {
+      ({underlineOnHover}: ITextLinkCommonProps) => {
         if (underlineOnHover) {
           return css`
             text-decoration: underline;
@@ -77,15 +77,16 @@ class TextLink<P> extends React.PureComponent<P & ITextLinkProps> {
   public render (): JSX.Element {
     if (this.isButton(this.props)) {
       const {
-        onClick,
         children,
-        textType,
         isInline,
+        onClick,
+        textType,
         underlineOnHover
       } = this.props
 
       return (
         <StyledTextButton
+          type='button'
           textType={textType}
           isInline={isInline}
           underlineOnHover={underlineOnHover}

--- a/src/domain/Links/TextLink/__snapshots__/TextLink.test.tsx.snap
+++ b/src/domain/Links/TextLink/__snapshots__/TextLink.test.tsx.snap
@@ -97,9 +97,11 @@ exports[`<TextLink /> should render a text link button 1`] = `
 >
   <styled.button
     isInline={true}
+    type="button"
   >
     <button
       className="c0"
+      type="button"
     >
       Text link me
     </button>


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
