### PR TITLE
[INT-5132] Add rightComponent to the board component

### DIFF
--- a/src/domain/Boards/Board/Board.examples.md
+++ b/src/domain/Boards/Board/Board.examples.md
@@ -68,6 +68,33 @@
 </Board>
 ```
 
+#### Board with right component
+   
+```jsx
+import { TextLink } from '@Domain/Links';
+
+<Board
+ label='Basic tiles'
+ rightComponent={
+  <TextLink
+    onClick={(e)=> {
+      e.preventDefault();
+      alert('I am the right component')
+    }}
+    textType='small'
+  >
+    I am the message
+  </TextLink>
+ }
+>
+ <Board.Tile
+  size='large'
+  onClick= {() => { alert('I am a large tile') }}
+ >
+ </Board.Tile>
+</Board>
+```
+
 #### Board with tiles with anchor href
    
 ```jsx

--- a/src/domain/Boards/Board/Board.test.tsx
+++ b/src/domain/Boards/Board/Board.test.tsx
@@ -15,4 +15,17 @@ describe('<Board />', () => {
 
     expect(wrapper).toMatchSnapshot()
   })
+
+  it(`should render a board with a right component`, () => {
+    const wrapper = shallow(
+      <Board
+        label='Basic board'
+        rightComponent={<div>This is a test right component</div>}
+      >
+        Children
+      </Board>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
 })

--- a/src/domain/Boards/Board/Board.tsx
+++ b/src/domain/Boards/Board/Board.tsx
@@ -1,19 +1,30 @@
 import React from 'react'
 
 import { Props } from '../../../common'
-import { BoardTilesWrapper, BoardWrapper, StyledBoardLabel } from './style'
+import { BoardTilesWrapper, BoardWrapper, StyledBoardLabel, StyledHeadingWrapper } from './style'
 import { Tile } from './subcomponents/Tile'
 
 interface IBoardProps {
   /** Text displayed above the board */
   label?: string
+  /** Message displayed after the label */
+  rightComponent?: JSX.Element | JSX.Element[] | string
   /** The data-component-context */
   componentContext?: string
 }
 export class Board extends React.PureComponent<IBoardProps> {
   public static Tile = Tile
 
-  private get label (): JSX.Element | null {
+  get heading (): JSX.Element {
+    return(
+      <StyledHeadingWrapper>
+        {this.label}
+        {this.message}
+      </StyledHeadingWrapper>
+    )
+  }
+
+  get label (): JSX.Element | null {
     const {
       label
     } = this.props
@@ -22,6 +33,18 @@ export class Board extends React.PureComponent<IBoardProps> {
       return (
         <StyledBoardLabel> {label} </StyledBoardLabel>
       )
+    }
+
+    return null
+  }
+
+  get message (): JSX.Element | null {
+    const {
+      rightComponent
+    } = this.props
+
+    if (rightComponent) {
+      return <> {rightComponent} </>
     }
 
     return null
@@ -38,7 +61,7 @@ export class Board extends React.PureComponent<IBoardProps> {
         data-component-type={Props.ComponentType.Board}
         data-component-context={componentContext}
       >
-        {this.label}
+        {this.heading}
         <BoardTilesWrapper> {children} </BoardTilesWrapper>
       </BoardWrapper>
     )

--- a/src/domain/Boards/Board/__snapshots__/Board.test.tsx.snap
+++ b/src/domain/Boards/Board/__snapshots__/Board.test.tsx.snap
@@ -4,11 +4,37 @@ exports[`<Board /> should render a board 1`] = `
 <styled.div
   data-component-type="board"
 >
-  <styled.label>
+  <styled.div>
+    <styled.label>
+       
+      Basic board
+       
+    </styled.label>
+  </styled.div>
+  <styled.div>
      
-    Basic board
+    Children
      
-  </styled.label>
+  </styled.div>
+</styled.div>
+`;
+
+exports[`<Board /> should render a board with a right component 1`] = `
+<styled.div
+  data-component-type="board"
+>
+  <styled.div>
+    <styled.label>
+       
+      Basic board
+       
+    </styled.label>
+     
+    <div>
+      This is a test right component
+    </div>
+     
+  </styled.div>
   <styled.div>
      
     Children

--- a/src/domain/Boards/Board/style.ts
+++ b/src/domain/Boards/Board/style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { Variables } from '../../../common'
+import { Utils, Variables } from '../../../common'
 
 const BoardWrapper = styled.div``
 
@@ -17,10 +17,25 @@ const StyledBoardLabel = styled.label`
   font-weight: ${Variables.FontWeight.fwHeavy};
   color: ${Variables.Color.n700};
   margin-bottom: 12px;
+
+  ${Utils.mediaQueryBetweenSizes({ maxPx: Variables.Breakpoint.breakpointTablet })} {
+    width: 100%;
+  }
+`
+
+const StyledHeadingWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  ${Utils.mediaQueryBetweenSizes({ maxPx: Variables.Breakpoint.breakpointTablet })} {
+    flex-wrap: wrap;
+    margin-bottom: ${Variables.Spacing.s2XSmall}px;
+  }
 `
 
 export {
   StyledBoardLabel,
   BoardWrapper,
-  BoardTilesWrapper
+  BoardTilesWrapper,
+  StyledHeadingWrapper
 }

--- a/src/domain/Forms/VerticalForm/VerticalForm.examples.md
+++ b/src/domain/Forms/VerticalForm/VerticalForm.examples.md
@@ -214,7 +214,7 @@ initialState = { textInputValue: '' };
     <VerticalForm.RightAlignControls>
       <Button
          type='primary'
-      >
+      >	
         Submit me :)
       </Button>
     </VerticalForm.RightAlignControls>

--- a/src/domain/Forms/VerticalForm/subcomponents/Field.test.tsx
+++ b/src/domain/Forms/VerticalForm/subcomponents/Field.test.tsx
@@ -68,32 +68,6 @@ describe('<Field />', () => {
     expect(wrapper).toMatchSnapshot()
   })
 
-  it(`should render a vertical form field with a action message`, () => {
-    const wrapper = shallow(
-      <Field
-        label='This is a test input'
-        actionMessage={<div>This is a test action message</div>}
-      >
-        Children
-      </Field>
-    )
-
-    expect(wrapper).toMatchSnapshot()
-  })
-
-  it(`should render a vertical form field with a action message`, () => {
-    const wrapper = shallow(
-      <Field
-        label='This is a test input'
-        actionMessage={<div>This is a test action message</div>}
-      >
-        Children
-      </Field>
-    )
-
-    expect(wrapper).toMatchSnapshot()
-  })
-
   it(`should render a vertical form field with a hint`, () => {
     const wrapper = shallow(
       <Field
@@ -103,6 +77,19 @@ describe('<Field />', () => {
           label: 'This is a test hint label',
           hintWrapperProps: { width: 200 }
         }}
+      >
+        Children
+      </Field>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it(`should render a vertical form field with a action message`, () => {
+    const wrapper = shallow(
+      <Field
+        label='This is a test input'
+        actionMessage={<div>This is a test action message</div>}
       >
         Children
       </Field>

--- a/src/domain/Forms/VerticalForm/subcomponents/Field.tsx
+++ b/src/domain/Forms/VerticalForm/subcomponents/Field.tsx
@@ -1,9 +1,9 @@
 import { isString, map } from 'lodash'
 import React from 'react'
+import { IHintWrapperProps } from 'src/domain/Formats/HintWrapper'
 
 import { Props } from '../../../../common'
 import { HintWrapper } from '../../../Formats'
-import { IHintWrapperProps } from '../../../Formats/HintWrapper'
 import { ITooltipPopoverProps, TooltipPopover } from '../../../Popovers/TooltipPopover'
 import { Text } from '../../../Typographies/Text'
 import {

--- a/src/domain/Forms/VerticalForm/subcomponents/__snapshots__/Field.test.tsx.snap
+++ b/src/domain/Forms/VerticalForm/subcomponents/__snapshots__/Field.test.tsx.snap
@@ -23,22 +23,6 @@ exports[`<Field /> should render a vertical form field with a action message 2`]
       isRequired={false}
     >
       This is a test input
-    </styled.label>
-  </styled.div>
-  Children
-  <div>
-    This is a test action message
-  </div>
-</styled.div>
-`;
-
-exports[`<Field /> should render a vertical form field with a action message 3`] = `
-<styled.div>
-  <styled.div>
-    <styled.label
-      isRequired={false}
-    >
-      This is a test input
       <styled.span>
         <TooltipPopover
           toggleComponent={[Function]}

--- a/src/domain/Forms/VerticalForm/subcomponents/style.ts
+++ b/src/domain/Forms/VerticalForm/subcomponents/style.ts
@@ -71,6 +71,7 @@ const StyledLabelWrapper = styled.div`
     margin-bottom: ${Variables.Spacing.s2XSmall}px;
   }
 `
+
 export {
   FieldWrapper,
   ErrorMessage,


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
