### PR TITLE
Dynamically change gutters in gridlayout for different screen sizes

### DIFF
--- a/src/domain/Layouts/GridLayout/GridLayout.examples.md
+++ b/src/domain/Layouts/GridLayout/GridLayout.examples.md
@@ -3,9 +3,11 @@ support for being used within react components.
 
 #### Simple sizing (different screen sizes)
 
-GridLayout works off a 12 position based grid. Any cells going off this will be positioned on the next row.
-Cell sizing work from the given size upwards, and will default to 12 otherwise.
-To size for all screen positions, use `min: X`
+GridLayout works using a 12 position-based grid.
+Any cells exceeding this will be positioned on the next row.
+
+Sizes can be given for all screen breakpoints, or can be
+individualised per breakpoint using `{ min: X, tablet: Y}` setup.
 
 ```jsx
 import { Variables } from '@Common';
@@ -21,11 +23,11 @@ const style = {
 <GridLayout
   cells={[
     {
-      size: { min: 10 },
+      size: 10,
       content: <div style={style}/>
     },
     {
-      size: { min: 2 },
+      size: 2,
       content: <div style={style}/>
     },
     {
@@ -44,11 +46,12 @@ const style = {
 />
 ```
 
-#### Auto and shrink cells
+#### Auto, shrink and fullWidth cells
 
 `shrink` will fit the cell to its content. `auto` will expand the cell to the rest of its row,
 shared between every cell with auto sizing.
-These options can be provided on a size basis or for the entire size on every screen.
+These options can be provided on a per-breakpoint basis or as an overall size across all
+breakpoints.
 
 ```jsx
 import { Variables } from '@Common';
@@ -81,6 +84,38 @@ const styleSmall = {
 />
 ```
 
+`size: 'fullWidth'` is a synonym for `size: 12` and can be semantically used wherever a full
+width cell is desired. The following will be three fullWidth cells on tablet or lower sizes:
+
+```jsx
+import { Variables } from '@Common';
+
+const style = {
+  backgroundColor: Variables.Color.n400,
+  border: `2px solid ${Variables.Color.n100}`,
+  minHeight: '2rem',
+  height: '100%',
+  width: '100%'
+};
+
+<GridLayout
+  cells={[
+    {
+      size: { desktop: 3, min: 'fullWidth' },
+      content: <div style={style}/>
+    },
+    {
+      size: { desktop: 6, min: 'fullWidth' },
+      content: <div style={style}/>
+    },
+    {
+      size: { desktop: 3, min: 'fullWidth' },
+      content: <div style={style}/>
+    }
+  ]}
+/>
+```
+
 #### Gutters
 
 Gutters can be added as margins and/or as padding between cells. Generally, you'll want to use margins,
@@ -101,11 +136,11 @@ const style = {
   gutterMarginY={Variables.Spacing.sSmall}
   cells={[
     {
-      size: { min: 10 },
+      size: 10,
       content: <div style={style}/>
     },
     {
-      size: { min: 2 },
+      size: 2,
       content: <div style={style}/>
     },
     {
@@ -138,23 +173,23 @@ const text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur
   gutterPaddingY={Variables.Spacing.sSmall}
   cells={[
     {
-      size: { min: 4 },
+      size: 4,
       content: text
     },
     {
-      size: { min: 4 },
+      size: 4,
       content: text
     },
     {
-      size: { min: 4 },
+      size: 4,
       content: text
     },
     {
-      size: { min: 4 },
+      size: 4,
       content: text
     },
     {
-      size: { min: 4 },
+      size: 4,
       content: text
     }
   ]}
@@ -177,11 +212,11 @@ const style = {
     gutterMarginX={Variables.Spacing.s2XSmall}
     cells={[
       {
-        size: { min: 6 },
+        size: 6,
         content: <div style={style}>spacing-2xsmall gutters</div>
       },
       {
-        size: { min: 6 },
+        size: 6,
         content: <div style={style}/>
       }
     ]}
@@ -190,11 +225,11 @@ const style = {
     gutterMarginX={Variables.Spacing.sMedium}
     cells={[
       {
-        size: { min: 6 },
+        size: 6,
         content: <div style={style}>spacing-medium gutters</div>
       },
       {
-        size: { min: 6 },
+        size: 6,
         content: <div style={style}/>
       }
     ]}
@@ -203,16 +238,56 @@ const style = {
     gutterMarginX={Variables.Layout.lLarge}
     cells={[
       {
-        size: { min: 6 },
+        size: 6,
         content: <div style={style}>layout-large gutters</div>
       },
       {
-        size: { min: 6 },
+        size: 6,
         content: <div style={style}/>
       }
     ]}
   />
 </>
+```
+
+Gutters also support being customised per breakpoint. The following will have large gutters
+on desktop but small gutters on mobile:
+```jsx
+import { Variables } from '@Common';
+
+const style = {
+  backgroundColor: Variables.Color.n400,
+  minHeight: '2rem',
+  height: '100%',
+  width: '100%'
+};
+
+<GridLayout
+  gutterMarginX={{ desktop: Variables.Spacing.sLarge, min: Variables.Spacing.sSmall }}
+  gutterMarginY={{ desktop: Variables.Spacing.sLarge, min: Variables.Spacing.sSmall }}
+  cells={[
+    {
+      size: 10,
+      content: <div style={style}/>
+    },
+    {
+      size: 2,
+      content: <div style={style}/>
+    },
+    {
+      size: { desktop: 3, tablet: 4 },
+      content: <div style={style}/>
+    },
+    {
+      size: { desktop: 6, tablet: 4 },
+      content: <div style={style}/>
+    },
+    {
+      size: { desktop: 3, tablet: 4 },
+      content: <div style={style}/>
+    }
+  ]}
+/>
 ```
 
 #### Offsets
@@ -236,12 +311,12 @@ const style = {
 <GridLayout
   cells={[
     {
-      size: { min: 4 },
+      size: 4,
       offset: { desktop: 7 },
       content: <div style={style}/>
     },
     {
-      size: { min: 1 },
+      size: 1,
       content: <div style={style}/>
     }
   ]}
@@ -267,11 +342,11 @@ const style = {
   <GridLayout
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Aligned to</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>the left (default)</div>
       }
     ]}
@@ -280,11 +355,11 @@ const style = {
     horizontalAlignment={GridLayout.HorizontalAlignment.Right}
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Aligned to</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>the right</div>
       }
     ]}
@@ -293,11 +368,11 @@ const style = {
     horizontalAlignment={GridLayout.HorizontalAlignment.Center}
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Aligned to</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>the center</div>
       }
     ]}
@@ -306,11 +381,11 @@ const style = {
     horizontalAlignment={GridLayout.HorizontalAlignment.Justify}
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Aligned to</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>push to the edges</div>
       }
     ]}
@@ -319,11 +394,11 @@ const style = {
     horizontalAlignment={GridLayout.HorizontalAlignment.Spaced}
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Aligned to</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>spread evenly</div>
       }
     ]}
@@ -353,11 +428,11 @@ const text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id 
     verticalAlignment={GridLayout.VerticalAlignment.Top}
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Aligned to the top</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>{text}</div>
       }
     ]}
@@ -366,11 +441,11 @@ const text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id 
     verticalAlignment={GridLayout.VerticalAlignment.Middle}
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Aligned to the middle</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>{text}</div>
       }
     ]}
@@ -379,11 +454,11 @@ const text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id 
     verticalAlignment={GridLayout.VerticalAlignment.Bottom}
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Aligned to the bottom</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>{text}</div>
       }
     ]}
@@ -392,11 +467,11 @@ const text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id 
     verticalAlignment={GridLayout.VerticalAlignment.Stretch}
     cells={[
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>Stretched to have the same height (default behaviour)</div>
       },
       {
-        size: { min: 4 },
+        size: 4,
         content: <div style={style}>{text}</div>
       }
     ]}
@@ -425,11 +500,11 @@ const style = {
   gridColumns={20}
   cells={[
     {
-      size: { min: 10 },
+      size: 10,
       content: <div style={style}/>
     },
     {
-      size: { min: 2 },
+      size: 2,
       content: <div style={style}/>
     },
     {
@@ -463,19 +538,19 @@ const text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id 
   gutterMarginY='large'
   cells={[
     {
-      size: { min: 12 },
+      size: 'fullWidth',
       content: <div style={style}>{text}</div>
     },
     {
-      size: { min: 12 },
+      size: 'fullWidth',
       content: <div style={style}>{text}</div>
     },
     {
-      size: { min: 12 },
+      size: 'fullWidth',
       content: <div style={style}>{text}</div>
     },
     {
-      size: { min: 12 },
+      size: 'fullWidth',
       content: <div style={style}>{text}</div>
     }
   ]}

--- a/src/domain/Layouts/GridLayout/GridLayout.test.tsx
+++ b/src/domain/Layouts/GridLayout/GridLayout.test.tsx
@@ -11,14 +11,14 @@ describe('<GridLayout />', () => {
         horizontalAlignment={GridLayout.HorizontalAlignment.Center}
         verticalAlignment={GridLayout.VerticalAlignment.Stretch}
         gutterMarginX={Variables.Spacing.s2XSmall}
-        gutterPaddingY={Variables.Layout.l2XSmall}
+        gutterPaddingY={{ min: Variables.Layout.l2XSmall, desktop: 'none' }}
         cells={[
           {
-            size: { min: 10 },
+            size: 10,
             content: <div>1</div>
           },
           {
-            size: { min: 2 },
+            size: 2,
             content: <div>2</div>
           },
           {
@@ -32,6 +32,7 @@ describe('<GridLayout />', () => {
           },
           {
             size: 'auto',
+            offset: 3,
             content: <div>5</div>
           }
         ]}

--- a/src/domain/Layouts/GridLayout/__snapshots__/GridLayout.test.tsx.snap
+++ b/src/domain/Layouts/GridLayout/__snapshots__/GridLayout.test.tsx.snap
@@ -12,8 +12,6 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  margin-left: -4px;
-  margin-right: -4px;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -34,10 +32,6 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
   min-height: 0;
   min-width: 0;
   width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  margin-left: 4px;
-  margin-right: 4px;
 }
 
 .c2 {
@@ -50,10 +44,6 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
   min-height: 0;
   min-width: 0;
   width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  margin-left: 4px;
-  margin-right: 4px;
 }
 
 .c3 {
@@ -66,10 +56,6 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
   min-height: 0;
   min-width: 0;
   width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  margin-left: 4px;
-  margin-right: 4px;
 }
 
 .c4 {
@@ -82,10 +68,6 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
   min-height: 0;
   min-width: 0;
   width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  margin-left: 4px;
-  margin-right: 4px;
 }
 
 .c5 {
@@ -98,71 +80,127 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
   min-height: 0;
   min-width: 0;
   width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  margin-left: 4px;
-  margin-right: 4px;
+}
+
+@media only screen and (max-width:639px) {
+  .c0 {
+    margin-left: -4px;
+    margin-right: -4px;
+  }
+}
+
+@media only screen and (min-width:640px) and (max-width:1033px) {
+  .c0 {
+    margin-left: -4px;
+    margin-right: -4px;
+  }
+}
+
+@media only screen and (min-width:1034px) and (max-width:1439px) {
+  .c0 {
+    margin-left: -4px;
+    margin-right: -4px;
+  }
+}
+
+@media only screen and (min-width:1440px) {
+  .c0 {
+    margin-left: -4px;
+    margin-right: -4px;
+  }
 }
 
 @media only screen and (max-width:639px) {
   .c1 {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(83.33333333333333% - 8px);
   }
 }
 
 @media only screen and (min-width:640px) and (max-width:1033px) {
   .c1 {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(83.33333333333333% - 8px);
   }
 }
 
 @media only screen and (min-width:1034px) and (max-width:1439px) {
   .c1 {
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(83.33333333333333% - 8px);
   }
 }
 
 @media only screen and (min-width:1440px) {
   .c1 {
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(83.33333333333333% - 8px);
   }
 }
 
 @media only screen and (max-width:639px) {
   .c2 {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(16.666666666666668% - 8px);
   }
 }
 
 @media only screen and (min-width:640px) and (max-width:1033px) {
   .c2 {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(16.666666666666668% - 8px);
   }
 }
 
 @media only screen and (min-width:1034px) and (max-width:1439px) {
   .c2 {
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(16.666666666666668% - 8px);
   }
 }
 
 @media only screen and (min-width:1440px) {
   .c2 {
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(16.666666666666668% - 8px);
   }
 }
 
 @media only screen and (max-width:639px) {
   .c3 {
-    -webkit-flex: 1 1 0px;
-    -ms-flex: 1 1 0px;
-    flex: 1 1 0px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
+    -webkit-flex: 1 1 0;
+    -ms-flex: 1 1 0;
+    flex: 1 1 0;
     width: auto;
   }
 }
 
 @media only screen and (min-width:640px) and (max-width:1033px) {
   .c3 {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(33.333333333333336% - 8px);
     margin-left: calc(16.666666666666668% + 4px);
   }
@@ -170,6 +208,8 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
 
 @media only screen and (min-width:1034px) and (max-width:1439px) {
   .c3 {
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(25% - 8px);
     margin-left: calc(16.666666666666668% + 4px);
   }
@@ -177,6 +217,8 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
 
 @media only screen and (min-width:1440px) {
   .c3 {
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(25% - 8px);
     margin-left: calc(16.666666666666668% + 4px);
   }
@@ -184,64 +226,92 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
 
 @media only screen and (max-width:639px) {
   .c4 {
-    -webkit-flex: 1 1 0px;
-    -ms-flex: 1 1 0px;
-    flex: 1 1 0px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
+    -webkit-flex: 1 1 0;
+    -ms-flex: 1 1 0;
+    flex: 1 1 0;
     width: auto;
   }
 }
 
 @media only screen and (min-width:640px) and (max-width:1033px) {
   .c4 {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(33.333333333333336% - 8px);
   }
 }
 
 @media only screen and (min-width:1034px) and (max-width:1439px) {
   .c4 {
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(50% - 8px);
   }
 }
 
 @media only screen and (min-width:1440px) {
   .c4 {
+    margin-left: 4px;
+    margin-right: 4px;
     width: calc(50% - 8px);
   }
 }
 
 @media only screen and (max-width:639px) {
   .c5 {
-    -webkit-flex: 1 1 0px;
-    -ms-flex: 1 1 0px;
-    flex: 1 1 0px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
+    -webkit-flex: 1 1 0;
+    -ms-flex: 1 1 0;
+    flex: 1 1 0;
     width: auto;
+    margin-left: calc(25% + 4px);
   }
 }
 
 @media only screen and (min-width:640px) and (max-width:1033px) {
   .c5 {
-    -webkit-flex: 1 1 0px;
-    -ms-flex: 1 1 0px;
-    flex: 1 1 0px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
+    -webkit-flex: 1 1 0;
+    -ms-flex: 1 1 0;
+    flex: 1 1 0;
     width: auto;
+    margin-left: calc(25% + 4px);
   }
 }
 
 @media only screen and (min-width:1034px) and (max-width:1439px) {
   .c5 {
-    -webkit-flex: 1 1 0px;
-    -ms-flex: 1 1 0px;
-    flex: 1 1 0px;
+    margin-left: 4px;
+    margin-right: 4px;
+    -webkit-flex: 1 1 0;
+    -ms-flex: 1 1 0;
+    flex: 1 1 0;
     width: auto;
+    margin-left: calc(25% + 4px);
   }
 }
 
 @media only screen and (min-width:1440px) {
   .c5 {
-    -webkit-flex: 1 1 0px;
-    -ms-flex: 1 1 0px;
-    flex: 1 1 0px;
+    margin-left: 4px;
+    margin-right: 4px;
+    -webkit-flex: 1 1 0;
+    -ms-flex: 1 1 0;
+    flex: 1 1 0;
     width: auto;
+    margin-left: calc(25% + 4px);
   }
 }
 
@@ -252,17 +322,13 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         "content": <div>
           1
         </div>,
-        "size": Object {
-          "min": 10,
-        },
+        "size": 10,
       },
       Object {
         "content": <div>
           2
         </div>,
-        "size": Object {
-          "min": 2,
-        },
+        "size": 2,
       },
       Object {
         "content": <div>
@@ -289,6 +355,7 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         "content": <div>
           5
         </div>,
+        "offset": 3,
         "size": "auto",
       },
     ]
@@ -297,7 +364,12 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
   gutterMarginX={4}
   gutterMarginY="none"
   gutterPaddingX="none"
-  gutterPaddingY={16}
+  gutterPaddingY={
+    Object {
+      "desktop": "none",
+      "min": 16,
+    }
+  }
   horizontalAlignment="center"
   verticalAlignment="stretch"
 >
@@ -318,28 +390,20 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         gutterMarginX={4}
         gutterMarginY="none"
         gutterPaddingX="none"
-        gutterPaddingY={16}
+        gutterPaddingY={
+          Object {
+            "desktop": "none",
+            "min": 16,
+          }
+        }
         key="0"
-        offsetsForBreakpoints={
-          Object {
-            "bigDesktop": 0,
-            "desktop": 0,
-            "min": 0,
-            "tablet": 0,
-          }
-        }
-        sizesForBreakpoints={
-          Object {
-            "bigDesktop": 10,
-            "desktop": 10,
-            "min": 10,
-            "tablet": 10,
-          }
-        }
+        offsets={0}
+        sizes={10}
       >
         <div
           className="c1"
           data-component-type="grid_layout_cell"
+          sizes={10}
         >
           <div>
             1
@@ -352,28 +416,20 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         gutterMarginX={4}
         gutterMarginY="none"
         gutterPaddingX="none"
-        gutterPaddingY={16}
+        gutterPaddingY={
+          Object {
+            "desktop": "none",
+            "min": 16,
+          }
+        }
         key="1"
-        offsetsForBreakpoints={
-          Object {
-            "bigDesktop": 0,
-            "desktop": 0,
-            "min": 0,
-            "tablet": 0,
-          }
-        }
-        sizesForBreakpoints={
-          Object {
-            "bigDesktop": 2,
-            "desktop": 2,
-            "min": 2,
-            "tablet": 2,
-          }
-        }
+        offsets={0}
+        sizes={2}
       >
         <div
           className="c2"
           data-component-type="grid_layout_cell"
+          sizes={2}
         >
           <div>
             2
@@ -386,21 +442,21 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         gutterMarginX={4}
         gutterMarginY="none"
         gutterPaddingX="none"
-        gutterPaddingY={16}
-        key="2"
-        offsetsForBreakpoints={
+        gutterPaddingY={
           Object {
-            "bigDesktop": 2,
-            "desktop": 2,
-            "min": 0,
+            "desktop": "none",
+            "min": 16,
+          }
+        }
+        key="2"
+        offsets={
+          Object {
             "tablet": 2,
           }
         }
-        sizesForBreakpoints={
+        sizes={
           Object {
-            "bigDesktop": 3,
             "desktop": 3,
-            "min": "auto",
             "tablet": 4,
           }
         }
@@ -408,6 +464,12 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         <div
           className="c3"
           data-component-type="grid_layout_cell"
+          sizes={
+            Object {
+              "desktop": 3,
+              "tablet": 4,
+            }
+          }
         >
           <div>
             3
@@ -420,21 +482,17 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         gutterMarginX={4}
         gutterMarginY="none"
         gutterPaddingX="none"
-        gutterPaddingY={16}
-        key="3"
-        offsetsForBreakpoints={
+        gutterPaddingY={
           Object {
-            "bigDesktop": 0,
-            "desktop": 0,
-            "min": 0,
-            "tablet": 0,
+            "desktop": "none",
+            "min": 16,
           }
         }
-        sizesForBreakpoints={
+        key="3"
+        offsets={0}
+        sizes={
           Object {
-            "bigDesktop": 6,
             "desktop": 6,
-            "min": "auto",
             "tablet": 4,
           }
         }
@@ -442,6 +500,12 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         <div
           className="c4"
           data-component-type="grid_layout_cell"
+          sizes={
+            Object {
+              "desktop": 6,
+              "tablet": 4,
+            }
+          }
         >
           <div>
             4
@@ -454,28 +518,20 @@ exports[`<GridLayout /> should render a GridLayout 1`] = `
         gutterMarginX={4}
         gutterMarginY="none"
         gutterPaddingX="none"
-        gutterPaddingY={16}
+        gutterPaddingY={
+          Object {
+            "desktop": "none",
+            "min": 16,
+          }
+        }
         key="4"
-        offsetsForBreakpoints={
-          Object {
-            "bigDesktop": 0,
-            "desktop": 0,
-            "min": 0,
-            "tablet": 0,
-          }
-        }
-        sizesForBreakpoints={
-          Object {
-            "bigDesktop": "auto",
-            "desktop": "auto",
-            "min": "auto",
-            "tablet": "auto",
-          }
-        }
+        offsets={3}
+        sizes="auto"
       >
         <div
           className="c5"
           data-component-type="grid_layout_cell"
+          sizes="auto"
         >
           <div>
             5


### PR DESCRIPTION
- Allow providing sizes on the top level (`size: 4` rather than `size: {min: 4}`)
- Add special `fullWidth` size as a synonym for the gridcolumns (12 by default)
- Allow customising gutter sizes by breakpoints as well.

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [x]  Examples have been provided for any new components or functionality
- [x]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [x]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [x]  The component has data-component-type and data-component-context attributes following the standard
