### PR TITLE
[INT-5313] [INT-5324] Fix weird spacing of button tile content in safari

### DIFF
--- a/src/domain/Boards/Board/subcomponents/style.tsx
+++ b/src/domain/Boards/Board/subcomponents/style.tsx
@@ -183,6 +183,7 @@ const StyledTileLabel = styled.span`
   width: 100%;
   display: block;
   white-space: nowrap;
+  margin-bottom: ${Variables.Spacing.s2XSmall}px;
   overflow: hidden;
   position: relative;
   text-overflow: ellipsis;
@@ -288,6 +289,7 @@ const ButtonDescriptionLabel = styled.span`
   color: ${Variables.Color.n600};
   display: block;
   height: 60px;
+  margin-bottom: ${Variables.Spacing.s2XSmall}px;
   overflow: hidden;
   position: relative;
 


### PR DESCRIPTION
INT-5313

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
