### PR TITLE
[INT-5294] Add focus styles to inputs without them.

### DIFF
--- a/src/domain/Inputs/CheckboxInput/style.scss
+++ b/src/domain/Inputs/CheckboxInput/style.scss
@@ -24,6 +24,22 @@
       }
     }
 
+    &:focus + label {
+      &.checkbox {
+        border-color: $i400;
+
+        &::before {
+          background-color: $n300;
+          border-color: $i400;
+        }
+      }
+
+      &.checkbox-button {
+        background-color: $n200;
+        border-color: $i400;
+      }
+    }
+
     &:checked + .checkbox {
       border-color: $i600;
 

--- a/src/domain/Inputs/IconPickerInput/style.ts
+++ b/src/domain/Inputs/IconPickerInput/style.ts
@@ -45,6 +45,11 @@ const StyledIconInput = styled.input`
   opacity: 0;
   position: absolute;
   width: 0;
+
+  &:focus + label {
+    border-color: ${Variables.Color.i400};
+    background: ${Variables.Color.n200};
+  }
 `
 
 export {

--- a/src/domain/Inputs/RadioInput/style.scss
+++ b/src/domain/Inputs/RadioInput/style.scss
@@ -14,6 +14,23 @@
       width: 100%;
     }
 
+
+    &:focus + label {
+      &.radio {
+        border-color: $i400;
+
+        &::before {
+          background-color: $n300;
+          border-color: $i400;
+        }
+      }
+
+      &.radio-button {
+        background-color: $n200;
+        border-color: $i400;
+      }
+    }
+
     &:disabled + .radio {
       color: $n500;
       cursor: not-allowed;


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
![image (2)](https://user-images.githubusercontent.com/14831681/54964086-d6544580-4fb6-11e9-8e49-26f087541ec0.png)
![image (3)](https://user-images.githubusercontent.com/14831681/54964102-e409cb00-4fb6-11e9-8ca9-8c1e35420c3c.png)
