### PR TITLE
[INT-6028] Create optional noDataText prop to pass to react-table.

### DIFF
--- a/src/domain/Tables/DataTable/AsyncDataTable/AsyncDataTable.tsx
+++ b/src/domain/Tables/DataTable/AsyncDataTable/AsyncDataTable.tsx
@@ -24,8 +24,6 @@ interface IAsyncDataTableProps extends IBaseDataTableProps {
    * @param pageIndex The new page number the user has selected
    */
   onPageChange: (pageIndex: number) => void
-  /** Text to display when there are no rows, defaults to react-table's default message */
-  noDataText?: string
   /** The component context */
   componentContext?: string
 }

--- a/src/domain/Tables/DataTable/DataTable/DataTable.tsx
+++ b/src/domain/Tables/DataTable/DataTable/DataTable.tsx
@@ -235,7 +235,8 @@ class DataTable extends React.Component<IDataTableProps, IDataTableState> {
       defaultPageSize,
       sortable,
       defaultSorted,
-      reactTableOverrides
+      reactTableOverrides,
+      noDataText
     } = this.props
 
     const filteredData = this.filteredData
@@ -244,6 +245,7 @@ class DataTable extends React.Component<IDataTableProps, IDataTableState> {
       <ReactTable
         {...this.defaultReactTableProps}
         data={filteredData}
+        noDataText={noDataText}
         columns={this.columns}
         className={this.classNames}
         showPagination={showPagination}

--- a/src/domain/Tables/DataTable/types.ts
+++ b/src/domain/Tables/DataTable/types.ts
@@ -23,6 +23,8 @@ interface IBaseDataTableProps {
   showVerticalLines?: boolean
   /** Placeholder replacement for when there is no data  */
   noDataComponent?: JSX.Element
+  /** Text to display when there are no rows, defaults to react-table's default message */
+  noDataText?: string
 
   /**
    * Overrides for react-table props which can be applied to this table.


### PR DESCRIPTION
This allows for custom empty table messages

[INT-6028]

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [x]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [x]  The component has data-component-type and data-component-context attributes following the standard
