### PR TITLE
[INT-6136] Add margin support to the brick component.

### DIFF
--- a/src/domain/Spacers/services/margins.examples.md
+++ b/src/domain/Spacers/services/margins.examples.md
@@ -64,4 +64,5 @@ import { Button } from '@Domain/Buttons';
 
 The components that support breakpoints are:
 * Button
+* Brick
 * Callout

--- a/src/domain/Typographies/Brick/Brick.tsx
+++ b/src/domain/Typographies/Brick/Brick.tsx
@@ -12,6 +12,8 @@ export interface IBrickProps {
   className?: string
   /** The data-component-context */
   componentContext?: string
+  /** The margins around the component */
+  margins?: Props.IMargins
 }
 
 export class Brick extends React.PureComponent<IBrickProps> {
@@ -27,11 +29,13 @@ export class Brick extends React.PureComponent<IBrickProps> {
       typographyType,
       className,
       componentContext,
-      children
+      children,
+      margins
     } = this.props
 
     return (
       <BrickWrapper
+        margins={margins}
         color={color!}
         className={className}
         typographyType={typographyType!}

--- a/src/domain/Typographies/Brick/style.ts
+++ b/src/domain/Typographies/Brick/style.ts
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components'
 
 import { Props, Variables } from '../../../common'
+import { styleForMargins } from '../../Spacers/services/margins'
 import { styleForTypographyType } from '../services/textStyles'
 
 interface IBrickWrapperProps {
@@ -8,6 +9,8 @@ interface IBrickWrapperProps {
   color: BrickColor
   /** Specify the type of typography to use */
   typographyType: Props.TypographyType
+  /** The margins around the component */
+  margins?: Props.IMargins
 }
 
 enum BrickColor {
@@ -62,6 +65,7 @@ const BrickWrapper = styled.span<IBrickWrapperProps>`
   padding: 1px 4px;
   word-break: break-word;
 
+  ${(props: IBrickWrapperProps) => styleForMargins(props.margins)}
   ${(props: IBrickWrapperProps) => styleForTypographyType(props.typographyType)}
   ${(props: IBrickWrapperProps) => {
     const color = colors[props.color]


### PR DESCRIPTION

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [x]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [x]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
