### PR TITLE
Bump react and react-dom to 16.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "peerDependencies": {
     "foundation-sites": "^6.4.3",
     "jquery": "^3.3.1",
-    "react": "^16.8.4",
-    "react-dom": "^16.3.1",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "styled-components": "^3.3.2"
   },
   "dependencies": {
@@ -105,7 +105,7 @@
     "postcss-loader": "2.1.3",
     "react": "16.8.6",
     "react-docgen-typescript": "1.12.4",
-    "react-dom": "16.8.6",
+    "react-dom": "^16.8.6",
     "react-styleguidist": "^9.0.0",
     "react-test-renderer": "16.3.1",
     "rimraf": "^2.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9473,7 +9473,7 @@ react-docgen@3.0.0-rc.2:
     node-dir "^0.1.10"
     recast "^0.16.0"
 
-react-dom@16.8.6:
+react-dom@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
