### PR TITLE
[INT-6455] Use EmptyState instead of generic Callout for empty SmartList

### DIFF
--- a/src/domain/Lists/SmartList/SmartList.tsx
+++ b/src/domain/Lists/SmartList/SmartList.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import uuid from 'uuid'
 
 import { Props } from '../../../common'
-import { Callout } from '../../Callouts'
+import { EmptyState } from '../../Callouts'
 import { Row } from '../../Grids/Row'
 import { ISkeletonProps } from '../../Skeletons'
 import { Spinner } from '../../Spinners'
@@ -253,9 +253,10 @@ class SmartList extends React.PureComponent<ISmartList, ISmartListState> {
 
     if (isEmpty(this.data) || every(this.data, ['hide', true])) {
       return (
-        <Callout type='' shouldFocus={false}>
-          {emptyListText}
-        </Callout>
+        <EmptyState
+          primaryMessage={emptyListText}
+          secondaryMessage={null}
+        />
       )
     }
 

--- a/src/domain/Lists/SmartList/__snapshots__/SmartList.test.tsx.snap
+++ b/src/domain/Lists/SmartList/__snapshots__/SmartList.test.tsx.snap
@@ -2661,29 +2661,21 @@ exports[`<SmartList /> should render an empty Smart List displaying the right da
         </GridProvider>
       </Row>
     </div>
-    <Callout
-      justifyCenter={false}
-      messages={Array []}
-      shouldFocus={false}
-      type=""
+    <EmptyState
+      primaryMessage="No Results found."
+      secondaryMessage={null}
     >
-      <styled.div
-        className="callout"
-        data-component-type="callout"
-        innerRef={[Function]}
+      <div
+        className="ihrEmptyState"
+        data-component-type="empty_state"
       >
         <div
-          className="callout "
-          data-component-type="callout"
+          className="ihrPrimaryMessage"
         >
-          <div
-            className="content"
-          >
-            No Results found.
-          </div>
+          No Results found.
         </div>
-      </styled.div>
-    </Callout>
+      </div>
+    </EmptyState>
   </div>
 </SmartList>
 `;


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
