### PR TITLE
[INT-6461] Make multi select inputs overflow when they have more items that available line length

### DIFF
--- a/src/domain/Inputs/SelectInput/style.scss
+++ b/src/domain/Inputs/SelectInput/style.scss
@@ -74,7 +74,7 @@
     }
 
     .Select-clear {
-      font-weight: 600;
+      font-weight: $fw-heavy;
     }
 
     .Select-option {
@@ -118,7 +118,7 @@
 
         // The following nesting is needed to overwrite library specificity
         .Select-value {
-          margin: 7px 0 0 8px;
+          margin: 7px 0 0 $spacing-xsmall;
 
           .Select-value-label {
             color: $n800;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/31597275/59332311-4615d900-8d39-11e9-8226-b46c110d9274.png)


**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
