### PR TITLE
[INT-6537] Update skeletons to use `block` instead of `inline-flex`

### DIFF
--- a/src/domain/Lists/SmartList/__snapshots__/SmartList.test.tsx.snap
+++ b/src/domain/Lists/SmartList/__snapshots__/SmartList.test.tsx.snap
@@ -2727,7 +2727,6 @@ exports[`<SmartList /> should render skeleton 1`] = `
 
 .c4 {
   border-radius: 4px;
-  width: 100%;
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   font-size: 16px;
@@ -2743,10 +2742,7 @@ exports[`<SmartList /> should render skeleton 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 @media only screen and (min-width:0em) {

--- a/src/domain/Skeletons/BlockSkeleton/__snapshots__/BlockSkeleton.test.tsx.snap
+++ b/src/domain/Skeletons/BlockSkeleton/__snapshots__/BlockSkeleton.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`<BlockSkeleton /> should render a block skeleton 1`] = `
 .c0 {
   border-radius: 4px;
   line-height: 1rem;
-  width: 100%;
   height: 1rem;
   -webkit-animation: jXsTbE .8s linear infinite alternate;
   animation: jXsTbE .8s linear infinite alternate;
@@ -13,10 +12,7 @@ exports[`<BlockSkeleton /> should render a block skeleton 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 <BlockSkeleton
@@ -43,10 +39,7 @@ exports[`<BlockSkeleton /> should render a block skeleton with set width and hei
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 <BlockSkeleton

--- a/src/domain/Skeletons/BlockSkeleton/style.ts
+++ b/src/domain/Skeletons/BlockSkeleton/style.ts
@@ -12,7 +12,7 @@ export interface IBlockSkeletonWrapperProps {
 export const BlockSkeletonWrapper = styled.span`
   border-radius: 4px;
   line-height: 1rem;
-  width: ${(props: IBlockSkeletonWrapperProps) => props.width ? `${props.width}` : '100%'};
+  width: ${(props: IBlockSkeletonWrapperProps) => props.width ? `${props.width}` : null};
   height: ${(props: IBlockSkeletonWrapperProps) => props.height ? `${props.height}` : '1rem'};
   ${(props: IBlockSkeletonWrapperProps) => styleForSkeletons(props.margins)};
 `

--- a/src/domain/Skeletons/CircleSkeleton/__snapshots__/CircleSkeleton.test.tsx.snap
+++ b/src/domain/Skeletons/CircleSkeleton/__snapshots__/CircleSkeleton.test.tsx.snap
@@ -13,10 +13,7 @@ exports[`<CircleSkeleton /> should render a circle skeleton 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 <CircleSkeleton
@@ -47,10 +44,7 @@ exports[`<CircleSkeleton /> should render a circle skeleton with set size 1`] = 
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 <CircleSkeleton

--- a/src/domain/Skeletons/ParagraphSkeleton/__snapshots__/ParagraphSkeleton.test.tsx.snap
+++ b/src/domain/Skeletons/ParagraphSkeleton/__snapshots__/ParagraphSkeleton.test.tsx.snap
@@ -19,15 +19,11 @@ exports[`<ParagraphSkeleton /> should render a paragraph skeleton 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 .c1 {
   border-radius: 4px;
-  width: 100%;
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   font-size: 16px;
@@ -43,10 +39,7 @@ exports[`<ParagraphSkeleton /> should render a paragraph skeleton 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 .c2 {
@@ -67,10 +60,7 @@ exports[`<ParagraphSkeleton /> should render a paragraph skeleton 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 <ParagraphSkeleton

--- a/src/domain/Skeletons/TextSkeleton/__snapshots__/TextSkeleton.test.tsx.snap
+++ b/src/domain/Skeletons/TextSkeleton/__snapshots__/TextSkeleton.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`<TextSkeleton /> should render a text skeleton 1`] = `
 .c0 {
   border-radius: 4px;
-  width: 100%;
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   font-size: 16px;
@@ -19,10 +18,7 @@ exports[`<TextSkeleton /> should render a text skeleton 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 <TextSkeleton
@@ -44,7 +40,6 @@ exports[`<TextSkeleton /> should render a text skeleton 1`] = `
 exports[`<TextSkeleton /> should render a text skeleton with set type 1`] = `
 .c0 {
   border-radius: 4px;
-  width: 100%;
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   font-size: 24px;
@@ -60,10 +55,7 @@ exports[`<TextSkeleton /> should render a text skeleton with set type 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 <TextSkeleton
@@ -101,10 +93,7 @@ exports[`<TextSkeleton /> should render a text skeleton with set width 1`] = `
   will-change: opacity;
   background-color: #E1E6EB;
   border: 1px solid #E1E6EB;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: block;
 }
 
 <TextSkeleton

--- a/src/domain/Skeletons/TextSkeleton/style.ts
+++ b/src/domain/Skeletons/TextSkeleton/style.ts
@@ -12,7 +12,7 @@ export interface ITextSkeletonWrapperProps {
 
 export const TextSkeletonWrapper = styled.span`
   border-radius: 4px;
-  width: ${(props: ITextSkeletonWrapperProps) => props.width ? `${props.width}` : '100%'};
+  width: ${(props: ITextSkeletonWrapperProps) => props.width ? `${props.width}` : null};
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   ${(props: ITextSkeletonWrapperProps) => styleForTypographyType(props.textType)};

--- a/src/domain/Skeletons/style.ts
+++ b/src/domain/Skeletons/style.ts
@@ -21,7 +21,7 @@ function styleForSkeletons (margins?: Props.IMargins) {
     will-change: opacity;
     background-color: ${Variables.Color.n300};
     border: 1px solid ${Variables.Color.n300};
-    display: inline-flex;
+    display: block;
     ${() => styleForMargins(margins)};
   `
  )


### PR DESCRIPTION
INT-6537

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
