### PR TITLE
[INT-6608] Remove padding from the first and last carousel tile.

### DIFF
--- a/src/domain/Layouts/Carousel/style.ts
+++ b/src/domain/Layouts/Carousel/style.ts
@@ -86,6 +86,14 @@ const CarouselTile = styled.div`
   border: 1px solid ${Variables.Color.n250};
   background-color: ${Variables.Color.n150};
   margin: 0 ${Variables.Spacing.sXSmall / 2}px;
+
+  &:first-of-type {
+    margin-left: 0;
+  }
+
+   &:last-of-type {
+    margin-right: 0;
+  }
 `
 
 export {


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
