### PR TITLE
[INT-6604] Export currencyText's transformer function so it can be used elsewhere.

### DIFF
--- a/src/domain/Typographies/CurrencyText/CurrencyText.examples.md
+++ b/src/domain/Typographies/CurrencyText/CurrencyText.examples.md
@@ -102,3 +102,11 @@
   <CurrencyText />
 ```
 
+#### Using Currency Text formatter externally
+
+CurrencyText exports it's formatter so that it can be used in
+other places
+
+```jsx
+  <div>{CurrencyText.formatter(1000, 2)}</div>
+```

--- a/src/domain/Typographies/CurrencyText/CurrencyText.tsx
+++ b/src/domain/Typographies/CurrencyText/CurrencyText.tsx
@@ -36,6 +36,15 @@ class CurrencyText extends React.PureComponent<ICurrencyTextProps> {
     flexAlign: false
   }
 
+  public static formatter = (value: string | number, decimalPlace?: number) => {
+    let moneyFormat = '0,0.'
+    if (decimalPlace) {
+      moneyFormat = padEnd(moneyFormat, moneyFormat.length + decimalPlace, '0')
+    }
+
+    return Numeral(value.toString()).format(moneyFormat)
+  }
+
   get prefix (): JSX.Element | null {
     const {
       prefix,
@@ -67,18 +76,13 @@ class CurrencyText extends React.PureComponent<ICurrencyTextProps> {
       valueHintComponentProps
     } = this.props
 
-    let moneyFormat = '0,0.'
-    if (decimalPlace) {
-      moneyFormat = padEnd(moneyFormat, moneyFormat.length + decimalPlace, '0')
-    }
-
     return (
       <Text
         type={valueType}
         color={valueColor}
         hintComponentProps={valueHintComponentProps}
       >
-        {Numeral(value!.toString()).format(moneyFormat)}
+        {CurrencyText.formatter(value!, decimalPlace)}
       </Text>
     )
   }


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [x]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [x]  The component has data-component-type and data-component-context attributes following the standard
