### PR TITLE
[INT-6612] Remove overflow hidden from person profile content.

### DIFF
--- a/src/domain/Layouts/PageLayout/PageLayout.examples.md
+++ b/src/domain/Layouts/PageLayout/PageLayout.examples.md
@@ -13,7 +13,7 @@ import { Variables } from '@Common';
     <div style={{backgroundColor: Variables.Color.n500, height: '240px'}}/>
   </PageLayout.Region>
   <PageLayout.Region regionType='content'>
-    <div style={{backgroundColor: Variables.Color.n600, height: '500px'}}/>
+    <div style={{backgroundColor: Variables.Color.n600, height: '500px', borderRadius: '4px'}}/>
   </PageLayout.Region>
 </PageLayout>
 ```
@@ -83,7 +83,7 @@ import { Variables } from '@Common';
     <div style={{backgroundColor: Variables.Color.n500, height: '240px'}}/>
   </div>
   <div class='ihr-layout__content'>
-    <div style={{backgroundColor: Variables.Color.n600, height: '500px'}}/>
+    <div style={{backgroundColor: Variables.Color.n600, height: '500px', borderRadius: '4px'}}/>
   </div>
 </div>
 ```

--- a/src/domain/Layouts/PageLayout/style.scss
+++ b/src/domain/Layouts/PageLayout/style.scss
@@ -32,7 +32,6 @@
       border-radius: $border-radius;
       margin-top: -41px;
       max-width:  $breakpoint-big-desktop / 12 * 10;
-      overflow: hidden;
       width: 100% / 12 * 10;
     }
   }
@@ -51,7 +50,6 @@
     .ihr-layout__content {
       border-bottom-left-radius: $border-radius;
       border-bottom-right-radius: $border-radius;
-      overflow: hidden;
       width: 100%;
     }
   }


### PR DESCRIPTION
This should hopefully fix date range pickers from not being cut off
when they go outside of the content. Hopefully it does not break
anything, ive had a quick check and nothing obviously broke.

[INT-6612]

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
