### PR TITLE
[INT-6712] Show clear on filter controller search only when there is text to clear.

### DIFF
--- a/src/domain/Inputs/Input/Input.tsx
+++ b/src/domain/Inputs/Input/Input.tsx
@@ -186,7 +186,7 @@ export class Input extends React.PureComponent<IInputProps> {
         <InputWrapper
           disabledPrefix={disabledPrefix}
           hasIcon={!!icon}
-          hasClearButton={!!handleClear}
+          hasClearButton={this.hasClearButton}
           hasTextIndent={!!(icon || disabledPrefix)}
           prefixWrapperWidth={get(this.prefixWrapperRef, 'current.clientWidth', 0)}
         >
@@ -198,6 +198,15 @@ export class Input extends React.PureComponent<IInputProps> {
     }
 
     return this.input()
+  }
+
+  private get hasClearButton (): boolean {
+    const {
+      handleClear,
+      value
+    } = this.props
+
+    return (!!value || value !== '') && !!handleClear
   }
 
   private get prefix (): JSX.Element | null {
@@ -225,7 +234,7 @@ export class Input extends React.PureComponent<IInputProps> {
       handleClear
     } = this.props
 
-    if (handleClear) {
+    if (this.hasClearButton) {
       return <StyleClearButton onClick={handleClear}>×</StyleClearButton>
     }
 


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [x]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
