### PR TITLE
[INT-6656] Allow form autocomplete prop to pass through

### DIFF
--- a/src/domain/Forms/VerticalForm/VerticalForm.test.tsx
+++ b/src/domain/Forms/VerticalForm/VerticalForm.test.tsx
@@ -48,4 +48,14 @@ describe('<VerticalForm />', () => {
     expect(mockHandleSubmit.mock.calls.length).toBe(1)
     expect(wrapper).toMatchSnapshot()
   })
+
+  it('should render with autoComplete when it is passed in', () => {
+    const wrapper = shallow(
+      <VerticalForm autoComplete='off'>
+        <Input name='testInput' type='text' />
+      </VerticalForm>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
 })

--- a/src/domain/Forms/VerticalForm/VerticalForm.tsx
+++ b/src/domain/Forms/VerticalForm/VerticalForm.tsx
@@ -4,7 +4,7 @@ import { Field } from './subcomponents/Field'
 import { LeftAlignControls } from './subcomponents/LeftAlignControls'
 import { RightAlignControls } from './subcomponents/RightAlignControls'
 
-class VerticalForm extends React.PureComponent<React.HTMLAttributes<HTMLFormElement>> {
+class VerticalForm extends React.PureComponent<React.FormHTMLAttributes<HTMLFormElement>> {
   public static Field = Field
   public static LeftAlignControls = LeftAlignControls
   public static RightAlignControls = RightAlignControls
@@ -13,6 +13,7 @@ class VerticalForm extends React.PureComponent<React.HTMLAttributes<HTMLFormElem
     const {
       onSubmit,
       onChange,
+      autoComplete,
       children
     } = this.props
 
@@ -20,6 +21,7 @@ class VerticalForm extends React.PureComponent<React.HTMLAttributes<HTMLFormElem
       <form
         onSubmit={onSubmit}
         onChange={onChange}
+        autoComplete={autoComplete}
       >
         {children}
       </form>

--- a/src/domain/Forms/VerticalForm/__snapshots__/VerticalForm.test.tsx.snap
+++ b/src/domain/Forms/VerticalForm/__snapshots__/VerticalForm.test.tsx.snap
@@ -44,3 +44,14 @@ exports[`<VerticalForm /> should render with an onChange and onSubmit attributes
   />
 </form>
 `;
+
+exports[`<VerticalForm /> should render with autoComplete when it is passed in 1`] = `
+<form
+  autoComplete="off"
+>
+  <Input
+    name="testInput"
+    type="text"
+  />
+</form>
+`;


### PR DESCRIPTION
INT-6656

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
