### PR TITLE
[INT-6969] Fix placeholder styling in ie.

### DIFF
--- a/src/common/sass/legacy/components/_form.scss
+++ b/src/common/sass/legacy/components/_form.scss
@@ -23,6 +23,10 @@ select {
 input,
 textarea,
 select {
+  &:-ms-input-placeholder { // sass-lint:disable-line no-vendor-prefixes
+    color: $n400;
+  }
+
   &:disabled{
     &,
     &:hover {

--- a/src/domain/Inputs/DateRangeInput/style.scss
+++ b/src/domain/Inputs/DateRangeInput/style.scss
@@ -172,6 +172,10 @@
         color: $r400;
       }
 
+      &:-ms-input-placeholder { // sass-lint:disable-line no-vendor-prefixes
+        color: $r400;
+      }
+
       &:focus,
       &:hover {
         color: $n700;

--- a/src/domain/Inputs/SingleDateInput/style.scss
+++ b/src/domain/Inputs/SingleDateInput/style.scss
@@ -124,6 +124,10 @@
         &::placeholder {
           color: $r400;
         }
+
+        &:-ms-input-placeholder {  // sass-lint:disable-line no-vendor-prefixes
+          color: $r400;
+        }
       }
     }
   }


### PR DESCRIPTION
Something seems to be overriding and since there is no way to view
where style is coming from for placeholder text in ie this is all
that can be done to solve the problem.

**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [ ]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
