### PR TITLE
[INT-7017] Add margin support to scrolling tab group.

### DIFF
--- a/src/common/types/props.ts
+++ b/src/common/types/props.ts
@@ -91,6 +91,7 @@ namespace Props {
     RadioInput = 'radio_input',
     Record = 'record',
     RecordName = 'record_name',
+    ScrollingTabGroup = 'scrolling_tab_group',
     SmartList = 'smart_list',
     SmartListColumn = 'smart_list_column',
     Statistic = 'statistic',

--- a/src/domain/Spacers/services/margins.examples.md
+++ b/src/domain/Spacers/services/margins.examples.md
@@ -69,3 +69,4 @@ The components that support margins are:
 * Carousel
 * FilterController
 * HighlightArea
+* ScrollingTabGroup

--- a/src/domain/Tabs/ScrollingTabGroup/ScrollingTabGroup.tsx
+++ b/src/domain/Tabs/ScrollingTabGroup/ScrollingTabGroup.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lodash'
 import React, { MouseEvent, RefObject } from 'react'
 
-import { Utils } from '../../../common'
+import { Props, Utils } from '../../../common'
 import { IntelliIcon } from '../../Icons'
 import {
   TabChevronButton,
@@ -42,6 +42,10 @@ export interface IScrollingTabGroupProps {
   onTabChange?: (tab: IScrollingTab, index: number) => void
   /** Callback when the scroll position changes */
   onScrollUpdate?: (newScrollValue: number) => void
+  /** The data-component-context */
+  componentContext?: string
+  /** The margins around the component */
+  margins?: Props.IMargins
 }
 
 export class ScrollingTabGroup extends React.Component<IScrollingTabGroupProps, never> {
@@ -84,7 +88,9 @@ export class ScrollingTabGroup extends React.Component<IScrollingTabGroupProps, 
 
   public render (): JSX.Element | null {
     const {
-      tabs
+      tabs,
+      componentContext,
+      margins
     } = this.props
 
     if (tabs.length === 0) {
@@ -92,7 +98,11 @@ export class ScrollingTabGroup extends React.Component<IScrollingTabGroupProps, 
     }
 
     return (
-      <TabGroupContainer>
+      <TabGroupContainer
+        data-component-context={componentContext}
+        data-component-type={Props.ComponentType.ScrollingTabGroup}
+        margins={margins}
+      >
         {this.leftChevron}
         {this.rightChevron}
         {this.tabList}

--- a/src/domain/Tabs/ScrollingTabGroup/__snapshots__/ScrollingTabGroup.test.tsx.snap
+++ b/src/domain/Tabs/ScrollingTabGroup/__snapshots__/ScrollingTabGroup.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ScrollingTabGroup /> Standard tabs with current index should match the snapshot 1`] = `
-<styled.div>
+<styled.div
+  data-component-type="scrolling_tab_group"
+>
   <styled.div>
     <styled.ul
       onScroll={[Function]}

--- a/src/domain/Tabs/ScrollingTabGroup/style.ts
+++ b/src/domain/Tabs/ScrollingTabGroup/style.ts
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components'
 
-import { Variables } from '../../../common'
+import { Props, Variables } from '../../../common'
+import { styleForMargins } from '../../Spacers/services/margins'
 
 const TabStyleConstants = {
   GroupHeight: 40,
@@ -8,10 +9,16 @@ const TabStyleConstants = {
   ScrollDuration: 250
 }
 
+interface ITabGroupContainerProps {
+  /** Margins around the highlight area */
+  margins?: Props.IMargins
+}
+
 const TabGroupContainer = styled.div`
   box-shadow: inset 0 -1px 0 0 ${Variables.Color.n300};
   height: ${TabStyleConstants.GroupHeight}px;
   width: 100%;
+  ${(props: ITabGroupContainerProps) => styleForMargins(props.margins)}
 `
 
 interface ITabChevronButtonProps {


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your MR, remove the line from your description.**
- [x]  Examples have been provided for any new components or functionality
- [ ]  The `styleguide.config.js` has been updated to show the component in the ui-component page
- [ ]  Test Coverage for any new or updated functionality
- [ ]  Updated components have been tested locally in lapis and SPA and work as expected
- [ ]  Use cases for new components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [x]  The component has data-component-type and data-component-context attributes following the standard
