### PR TITLE
Don't force consumers of ui-components to do css compilation

### DIFF
--- a/src/domain/Inputs/DateRangeInput/DateRangeInput.tsx
+++ b/src/domain/Inputs/DateRangeInput/DateRangeInput.tsx
@@ -3,7 +3,6 @@ import moment, { Moment } from 'moment'
 import React from 'react'
 import { DateRangePicker, FocusedInputShape } from 'react-dates'
 import 'react-dates/initialize'
-import 'react-dates/lib/css/_datepicker.css'
 
 import { Variables } from '../../../common'
 import { FontAwesomeIcon } from '../../Icons/FontAwesomeIcon'

--- a/src/domain/Inputs/DateRangeInput/style.scss
+++ b/src/domain/Inputs/DateRangeInput/style.scss
@@ -1,4 +1,5 @@
 @import '../../../common/sass/variables';
+@import '~react-dates/lib/css/_datepicker.css';
 
 :local(.dateRangePickerOverrides) {
   .CalendarMonth_table {

--- a/src/domain/Inputs/SingleDateInput/SingleDateInput.tsx
+++ b/src/domain/Inputs/SingleDateInput/SingleDateInput.tsx
@@ -4,7 +4,6 @@ import moment, { Moment } from 'moment'
 import React from 'react'
 import { SingleDatePicker } from 'react-dates'
 import 'react-dates/initialize'
-import 'react-dates/lib/css/_datepicker.css'
 
 import { FontAwesomeIcon } from '../../Icons/FontAwesomeIcon'
 import { InputGroupPosition } from '../InputGroup'

--- a/src/domain/Inputs/SingleDateInput/style.scss
+++ b/src/domain/Inputs/SingleDateInput/style.scss
@@ -1,4 +1,5 @@
 @import '../../../common/sass/variables';
+@import '~react-dates/lib/css/_datepicker.css';
 
 :local(.singleDatePickerOverrides) {
   .CalendarMonth_table {


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
