### PR TITLE
Fix incorrect filterlist type making it unusable

### DIFF
--- a/src/domain/Lists/FilteredList/FilteredList.tsx
+++ b/src/domain/Lists/FilteredList/FilteredList.tsx
@@ -25,7 +25,7 @@ type Filter = IValueFilter
 
 type DataFetchCallback = (filters?: Filter[]) => Promise<any[]>
 
-type RenderCallback = (args: IFilteredListProps | { row: any, filteredRows: any[], index: number }) => JSX.Element | null | undefined
+type RenderCallback = (args: IFilteredListProps & { row: any, filteredRows: any[], index: number }) => JSX.Element | null | undefined
 type ErrorCallback = (errors: any) => JSX.Element | null | undefined
 
 interface IFilteredListProps {


### PR DESCRIPTION
The type was using a union rather than a join of types, which means it's not possible to actually use this callback in typescript as intended as you can't access the keys

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [x]  New and updated components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
