### PR TITLE
INT-9359 Fix avatar group last item font colour when maxAvatarCount is equal to avatar length

### DIFF
--- a/src/domain/Avatars/AvatarGroup/AvatarGroup.tsx
+++ b/src/domain/Avatars/AvatarGroup/AvatarGroup.tsx
@@ -113,7 +113,8 @@ class AvatarGroup extends React.PureComponent<IAvatarGroup, IAvatarGroupState> {
   private getAvatarForProps = (avatarProps: IAvatarGroupAvatar, index: number) => {
     const {
       maxAvatarCount,
-      size
+      size,
+      avatars
     } = this.props
 
     const {
@@ -140,7 +141,7 @@ class AvatarGroup extends React.PureComponent<IAvatarGroup, IAvatarGroupState> {
         avatarIndex={index}
         avatarGroupSize={size!}
         isInitials={isInitials}
-        isOverflow={maxAvatarCount !== null && index === maxAvatarCount! - 1}
+        isOverflow={maxAvatarCount !== null && index === maxAvatarCount! - 1 && avatars.length > maxAvatarCount!}
       >
         {avatarContent}
       </StyledAvatar>


### PR DESCRIPTION
INT-9359

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
