### PR TITLE
[INT-10732] Use auto-fill instead of auto-fit in AvatarBoard

### DIFF
--- a/src/domain/Boards/AvatarBoard/style.ts
+++ b/src/domain/Boards/AvatarBoard/style.ts
@@ -11,7 +11,7 @@ const AvatarBoardWrapper = styled.div<IBoardWrapperProps>`
   ${(props) => styleForMargins(props.margins)}
 
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: ${Variables.Spacing.sXLarge}px;
   justify-content: center;
   justify-items: center;


### PR DESCRIPTION
This stops results that don't fill up a row from stretching to fit the entire row

[INT-10732]

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
