### PR TITLE
Release 355

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,7 +194,7 @@ pipeline {
           steps {
             sshagent (credentials: ['GITHUB_CI_SSH_KEY']) {
               script {
-                env.NPM_TOKEN = helper.getSSMParameter('shared.NPM_TOKEN')
+                env.NPM_TOKEN = helper.getSSMParameter('/shared/NPM_TOKEN')
                 env.RELEASE_VERSION = RELEASE_VERSION
               }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@intellihr/ui-components",
   "description": "A common React components library that is used in our company",
-  "version": "45.5.2",
+  "version": "45.5.3",
   "main": "./dist/",
   "types": "./types/index.d.ts",
   "files": [

--- a/src/domain/Avatars/Avatar/Avatar.tsx
+++ b/src/domain/Avatars/Avatar/Avatar.tsx
@@ -49,6 +49,7 @@ export interface IAvatarState {
 }
 
 class Avatar extends React.Component<IAvatarProps> {
+  public static StatusDotColor = AvatarStatusDotColor
   public static defaultProps: IAvatarProps = {
     size: Props.AvatarSize.Medium
   }

--- a/src/domain/Cards/Card/style.ts
+++ b/src/domain/Cards/Card/style.ts
@@ -126,6 +126,7 @@ const StyledCardToggleButton = styled.button`
 const StyledActionButton = styled.button<IStyleActionButtonProps>`
   ${cardButtonStyle};
   transition: .1s ease-in;
+  z-index: 1;
 
   &:hover {
     background-color: ${(props: IStyleActionButtonProps) => colorOptions[props.color].hoverButtonBackground};

--- a/src/domain/Cards/GroupCard/style.ts
+++ b/src/domain/Cards/GroupCard/style.ts
@@ -104,6 +104,7 @@ const StyledGroupCardToggleButton = styled.button<IStyledGroupCardToggleButtonPr
 const StyledBodyActionButton = styled.button`
   ${cardButtonStyle};
   transition: .1s ease-in;
+  z-index: 1;
 
   &:hover {
     background-color: ${(props: IStyleActionButtonProps) => colorOptions[props.color].hoverButtonBackground};

--- a/src/domain/Tables/Table/Table.examples.md
+++ b/src/domain/Tables/Table/Table.examples.md
@@ -368,6 +368,7 @@ const successRowContentOverride = (
 ```jsx
 import { Text } from '@Domain/Typographies';
 import { Variables, Props } from '@Common';
+import { EmptyState } from '@Domain/Callouts';
 
 initialState = {
 sort: {createAt: 'ascending'}
@@ -378,14 +379,10 @@ sort: {createAt: 'ascending'}
   sort={state.sort}
   onSortChange={(sort) => setState({sort})}
   emptyState = {
-    <div style={{textAlign: 'center'}}>
-      <Text isInline={false} type='heading'>
-        Could not find any matching search results.
-      </Text>
-      <Text isInline={false} type='body'>
-        Try changing the filters or search term
-      </Text>
-    </div>
+    <EmptyState
+      primaryMessage='Could not find any matching search results.'
+      secondaryMessage='Try changing the filters or search term'
+    />
   }
   columns={[
     {

--- a/src/domain/Tables/Table/Table.tsx
+++ b/src/domain/Tables/Table/Table.tsx
@@ -11,7 +11,8 @@ import { TableRowVariant } from './services/colors'
 import {
   getSelectAllTableCheckboxInputValue,
   getUpdatedAllSelectableRows,
-  handleSelectionChanged
+  handleSelectionChanged,
+  validateProps
 } from './services/helper'
 import {
   StyledEmptyStateCell,
@@ -132,6 +133,7 @@ const Table = <T extends{}>(props: ITableProps<T>) => {
     hasSortEnabled = true
   } = props
 
+  validateProps(props)
   const [selectedAll, setSelectedAll] = useState<TableCheckboxInputValue>(TableCheckboxInputValue.False)
   const [selectedRows, setSelectedRows] = useState<ISelectedRows>(getUpdatedAllSelectableRows(rows, {}))
   const [expandedSwipeCellRow, setExpandedSwipeCellRow] = useState<string | null>(null)
@@ -238,5 +240,6 @@ export {
   IColumnProps,
   ISelectedRows,
   IColumnSorts,
+  ITableProps,
   getActionsIconButtonGroup
 }

--- a/src/domain/Tables/Table/Table.tsx
+++ b/src/domain/Tables/Table/Table.tsx
@@ -1,55 +1,45 @@
-import { mapValues } from 'lodash'
-import React, { useEffect, useState } from 'react'
-import { Transition, TransitionGroup } from 'react-transition-group'
+import { isEqual } from 'lodash'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Props } from '../../../common'
 import {
-  FontAwesomeIconButton,
   IFontAwesomeIconButtonProps
 } from '../../Buttons/FontAwesomeIconButton/FontAwesomeIconButton'
 import { TableRowVariant } from './services/colors'
 import {
   getSelectAllTableCheckboxInputValue,
   getUpdatedAllSelectableRows,
-  handleSelectionChanged,
-  validateProps
+  handleSelectionChanged
 } from './services/helper'
 import {
   StyledEmptyStateCell,
   StyledEmptyStateRow,
-  StyledFontAwesomeIconButtonWrapper,
   StyledTHead,
-  StyledTable, StyledTableWrapper
+  StyledTable,
+  StyledTableWrapper
 } from './services/style'
+import {
+  ColumnAlignment,
+  ColumnSize,
+  ColumnSortDirection,
+  IColumnProps,
+  IColumnSorts,
+  IRowProps,
+  ISelectedRows,
+  InteractionType
+} from './services/types'
 import { TableCheckboxInputValue } from './subcomponents/TableCheckboxInput'
 import { TableHeader } from './subcomponents/TableHeader'
 import { TableRow } from './subcomponents/TableRow'
 
-enum ColumnSize {
-  Auto = 'auto',
-  Shrink = 'shrink'
-}
-enum ColumnSortDirection {
-  Descending = 'descending',
-  Ascending = 'ascending'
-}
+const validateProps = <T extends {}>(props: ITableProps<T>) => {
+  if (props.hasLeftAction && props.interactionType === InteractionType.Swipe) {
+    throw new Error('Having left actions is not compatible with swipe interaction')
+  }
 
-enum ColumnAlignment {
-  Left = 'left',
-  Right = 'right'
-}
-
-enum InteractionType {
-  Hover = 'hover',
-  Swipe = 'swipe'
-}
-
-interface ISelectedRows {
-  [rowId: string]: boolean
-}
-
-interface IColumnSorts {
-  [columnName: string]: ColumnSortDirection
+  if (props.onSortChange && !props.sort) {
+    throw new Error('You must provide a sort for onSortChange to work')
+  }
 }
 
 interface ITableProps <T extends {}> {
@@ -81,42 +71,7 @@ interface ITableProps <T extends {}> {
   componentContext?: string
 }
 
-interface IRowProps <T> {
-  id: string
-  isSelectable?: boolean
-  isRemovable?: boolean
-  tooltipText?: string
-  progress?: number
-  variant?: TableRowVariant
-  data: T
-  contentOverride?: (rowData: T) => JSX.Element[] | JSX.Element
-  onClick?: (rowData: T) => void
-  actions?: IFontAwesomeIconButtonProps[]
-}
-
-interface IColumnProps <T> {
-  name: string
-  title?: string
-  size: ColumnSize
-  headerSize?: ColumnSize
-  content: (rowData: T) => JSX.Element
-  alignment?: ColumnAlignment
-  tooltipText?: (rowData: T) => string
-}
-
-const getActionsIconButtonGroup = (actions?: IFontAwesomeIconButtonProps[], name?: string) => {
-  if (actions) {
-    return (
-      <div>
-        {actions.map((actionProps, index) => (<StyledFontAwesomeIconButtonWrapper key={`actions-${name}-${index}`}><FontAwesomeIconButton {...actionProps}/></StyledFontAwesomeIconButtonWrapper>))}
-      </div>
-      )
-  }
-
-  return null
-}
-
-const Table = <T extends{}>(props: ITableProps<T>) => {
+const Table = <T extends {}>(props: ITableProps<T>) => {
   const {
     onRowRemove,
     rows,
@@ -134,12 +89,33 @@ const Table = <T extends{}>(props: ITableProps<T>) => {
   } = props
 
   validateProps(props)
-  const [selectedAll, setSelectedAll] = useState<TableCheckboxInputValue>(TableCheckboxInputValue.False)
-  const [selectedRows, setSelectedRows] = useState<ISelectedRows>(getUpdatedAllSelectableRows(rows, {}))
+  const [selectedRows, setSelectedRows] = useState<ISelectedRows>(() => getUpdatedAllSelectableRows(rows, {}))
   const [expandedSwipeCellRow, setExpandedSwipeCellRow] = useState<string | null>(null)
 
+  const selectAllTableCheckboxInputValue = useMemo(() => getSelectAllTableCheckboxInputValue(Object.values(selectedRows)), [selectedRows])
+
+  const setAllRows = useCallback((value: TableCheckboxInputValue) => {
+    const newSelectedRows = rows.reduce<ISelectedRows>((acc, row) => {
+      acc[row.id] = (value === TableCheckboxInputValue.True)
+
+      return acc
+    }, {})
+
+    setSelectedRows(newSelectedRows)
+  }, [rows, setSelectedRows])
+
+  const toggleSingleRow = useCallback((row: IRowProps<T>) => {
+    setSelectedRows(
+      (selectedRowsFromState) => ({...selectedRowsFromState, [row.id]: !selectedRowsFromState[row.id] })
+    )
+  }, [setSelectedRows])
+
   useEffect(() => {
-    setSelectedRows(getUpdatedAllSelectableRows<T>(rows, selectedRows))
+    const updatedSelectedRows = getUpdatedAllSelectableRows<T>(rows, selectedRows)
+
+    if (!isEqual(updatedSelectedRows, selectedRows)) {
+      setSelectedRows(updatedSelectedRows)
+    }
   }, [rows])
   useEffect(() => {
     if (hasLeftAction) {
@@ -147,22 +123,8 @@ const Table = <T extends{}>(props: ITableProps<T>) => {
     }
   }, [hasLeftAction])
   useEffect(() => {
-    if (selectedAll === TableCheckboxInputValue.False ) {
-      setSelectedRows(mapValues(selectedRows, () => false))
-    }
-
-    if (selectedAll === TableCheckboxInputValue.True ) {
-      setSelectedRows(mapValues(selectedRows, () => true))
-    }
-  }, [selectedAll])
-
-  useEffect(() => {
-    if (hasLeftAction) {
-      const currentSelectedRows = Object.values(selectedRows)
-      setSelectedAll(getSelectAllTableCheckboxInputValue(currentSelectedRows))
-      if (onSelectedRowChange) {
-        handleSelectionChanged<T>(rows, selectedRows, onSelectedRowChange)
-      }
+    if (hasLeftAction && onSelectedRowChange) {
+      handleSelectionChanged<T>(rows, selectedRows, onSelectedRowChange)
     }
   }, [selectedRows])
 
@@ -180,66 +142,62 @@ const Table = <T extends{}>(props: ITableProps<T>) => {
             sort={sort}
             onSortChange={onSortChange}
             columns={columns}
-            selectedAll={selectedAll}
-            setSelectedAll={setSelectedAll}
+            selectAllTableCheckboxInputValue={selectAllTableCheckboxInputValue}
+            setSelectAllTableCheckboxInputValue={setAllRows}
             hasLeftAction={hasLeftAction}
             bulkActions={bulkActions}
             hasTableSwipeActions={hasTableSwipeActions}
-            hasBulkAction={selectedAll !== TableCheckboxInputValue.False}
+            hasBulkAction={selectAllTableCheckboxInputValue !== TableCheckboxInputValue.False}
             isEmpty={rows.length === 0}
             hasSortEnabled={hasSortEnabled}
           />
         </StyledTHead>
-        <TransitionGroup className='table-rows' component='tbody'>
           {
             rows.length === 0 ? (
-              <StyledEmptyStateRow><StyledEmptyStateCell colSpan={columns.length}>{emptyState}</StyledEmptyStateCell></StyledEmptyStateRow>
-            ) : rows.map((row: IRowProps<T>, index) => (
-                <Transition
-                  key={row.id}
-                  timeout={500}
-                  mountOnEnter
-                  unmountOnExit
-                >
-                  { (state: 'entering' | 'entered' | 'exiting' | 'exited') => (
-                    <TableRow<T>
-                      transitionState={state}
-                      hasTableSwipeActions={hasTableSwipeActions}
-                      columns={columns}
-                      row={row}
-                      lastRow={index === rows.length - 1}
-                      selectedAll={selectedAll}
-                      selectedRows={selectedRows}
-                      setSelectedRows={setSelectedRows}
-                      hasLeftAction={hasLeftAction}
-                      interactionType={interactionType}
-                      onRowRemove={onRowRemove}
-                      expandedSwipeCellRow={expandedSwipeCellRow}
-                      setExpandedSwipeCellRow={setExpandedSwipeCellRow}
-                    />
-                  )}
-
-                </Transition>
+              <StyledEmptyStateRow>
+                <StyledEmptyStateCell colSpan={columns.length}>
+                  {emptyState}
+                </StyledEmptyStateCell>
+              </StyledEmptyStateRow>
+            ) : rows.map((row, index) => (
+              <TableRow<T>
+                key={row.id}
+                row={row}
+                lastRow={index === rows.length - 1}
+                hasTableSwipeActions={hasTableSwipeActions}
+                columns={columns}
+                isSelected={selectedRows[row.id] || false}
+                toggleSelected={toggleSingleRow}
+                hasLeftAction={hasLeftAction}
+                interactionType={interactionType}
+                onRowRemove={onRowRemove}
+                expandedSwipeCellRow={expandedSwipeCellRow}
+                setExpandedSwipeCellRow={setExpandedSwipeCellRow}
+              />
             ))
           }
-        </TransitionGroup>
       </StyledTable>
     </StyledTableWrapper>
   )
 }
 
-Table.ColumnSize = ColumnSize
-Table.ColumnAlignment = ColumnAlignment
-Table.ColumnSortDirection = ColumnSortDirection
-Table.InteractionType = InteractionType
-Table.RowVariant = TableRowVariant
+type ITableType = typeof Table & {
+  ColumnAlignment: typeof ColumnAlignment
+  ColumnSize: typeof ColumnSize
+  ColumnSortDirection: typeof ColumnSortDirection
+  InteractionType: typeof InteractionType
+  RowVariant: typeof TableRowVariant
+}
+
+const MemoTable: ITableType = React.memo(Table) as any
+
+MemoTable.ColumnSize = ColumnSize
+MemoTable.ColumnAlignment = ColumnAlignment
+MemoTable.ColumnSortDirection = ColumnSortDirection
+MemoTable.InteractionType = InteractionType
+MemoTable.RowVariant = TableRowVariant
 
 export {
-  Table,
-  IRowProps,
-  IColumnProps,
-  ISelectedRows,
-  IColumnSorts,
-  ITableProps,
-  getActionsIconButtonGroup
+  Table as UnmemoTable, // Needed for styleguide (memoed components won't be detected)
+  MemoTable as Table
 }

--- a/src/domain/Tables/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/domain/Tables/Table/__snapshots__/Table.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Table /> should render a mobile table 1`] = `
 >
   <styled.table>
     <styled.thead>
-      <TableHeader
+      <Memo(TableHeader)
         columns={
           Array [
             Object {
@@ -31,8 +31,8 @@ exports[`<Table /> should render a mobile table 1`] = `
         hasTableSwipeActions={true}
         isEmpty={false}
         onSortChange={[MockFunction]}
-        selectedAll="false"
-        setSelectedAll={[Function]}
+        selectAllTableCheckboxInputValue="false"
+        setSelectAllTableCheckboxInputValue={[Function]}
         sort={
           Object {
             "createAt": "ascending",
@@ -40,102 +40,351 @@ exports[`<Table /> should render a mobile table 1`] = `
         }
       />
     </styled.thead>
-    <TransitionGroup
-      childFactory={[Function]}
-      className="table-rows"
-      component="tbody"
-    >
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="0"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="1"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="2"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="3"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="4"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-    </TransitionGroup>
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={false}
+      hasTableSwipeActions={true}
+      interactionType="swipe"
+      isSelected={false}
+      key="0"
+      lastRow={false}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "fail.pdf",
+            "fileType": "PDF",
+            "size": "8.2",
+          },
+          "id": "0",
+          "isRemovable": true,
+          "isSelectable": false,
+          "onClick": [MockFunction],
+          "rowContentOverride": [Function],
+          "variant": "error",
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={false}
+      hasTableSwipeActions={true}
+      interactionType="swipe"
+      isSelected={false}
+      key="1"
+      lastRow={false}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "contentOverride": [Function],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "uploading.pdf",
+            "fileType": "PDF",
+            "size": "99",
+          },
+          "id": "1",
+          "isRemovable": true,
+          "isSelectable": false,
+          "progress": 0.7,
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={false}
+      hasTableSwipeActions={true}
+      interactionType="swipe"
+      isSelected={false}
+      key="2"
+      lastRow={false}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "contentOverride": [Function],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "success.pdf",
+            "fileType": "PDF",
+            "size": "3.7",
+          },
+          "id": "2",
+          "isRemovable": true,
+          "isSelectable": false,
+          "progress": 0.5,
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={false}
+      hasTableSwipeActions={true}
+      interactionType="swipe"
+      isSelected={false}
+      key="3"
+      lastRow={false}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "test.pdf",
+            "fileType": "PDF",
+            "size": "2.2",
+          },
+          "id": "3",
+          "isSelectable": true,
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={false}
+      hasTableSwipeActions={true}
+      interactionType="swipe"
+      isSelected={false}
+      key="4"
+      lastRow={true}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "test1.pdf",
+            "fileType": "PDF",
+            "size": "1.5",
+          },
+          "id": "4",
+          "isSelectable": true,
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
   </styled.table>
 </styled.div>
 `;
@@ -146,7 +395,7 @@ exports[`<Table /> should render a table 1`] = `
 >
   <styled.table>
     <styled.thead>
-      <TableHeader
+      <Memo(TableHeader)
         columns={
           Array [
             Object {
@@ -171,8 +420,8 @@ exports[`<Table /> should render a table 1`] = `
         hasTableSwipeActions={false}
         isEmpty={false}
         onSortChange={[MockFunction]}
-        selectedAll="false"
-        setSelectedAll={[Function]}
+        selectAllTableCheckboxInputValue="false"
+        setSelectAllTableCheckboxInputValue={[Function]}
         sort={
           Object {
             "createAt": "ascending",
@@ -180,102 +429,351 @@ exports[`<Table /> should render a table 1`] = `
         }
       />
     </styled.thead>
-    <TransitionGroup
-      childFactory={[Function]}
-      className="table-rows"
-      component="tbody"
-    >
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="0"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="1"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="2"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="3"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="4"
-        mountOnEnter={true}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={500}
-        unmountOnExit={true}
-      >
-        <Component />
-      </Transition>
-    </TransitionGroup>
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={true}
+      hasTableSwipeActions={false}
+      interactionType="hover"
+      isSelected={false}
+      key="0"
+      lastRow={false}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "fail.pdf",
+            "fileType": "PDF",
+            "size": "8.2",
+          },
+          "id": "0",
+          "isRemovable": true,
+          "isSelectable": false,
+          "onClick": [MockFunction],
+          "rowContentOverride": [Function],
+          "variant": "error",
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={true}
+      hasTableSwipeActions={false}
+      interactionType="hover"
+      isSelected={false}
+      key="1"
+      lastRow={false}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "contentOverride": [Function],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "uploading.pdf",
+            "fileType": "PDF",
+            "size": "99",
+          },
+          "id": "1",
+          "isRemovable": true,
+          "isSelectable": false,
+          "progress": 0.7,
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={true}
+      hasTableSwipeActions={false}
+      interactionType="hover"
+      isSelected={false}
+      key="2"
+      lastRow={false}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "contentOverride": [Function],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "success.pdf",
+            "fileType": "PDF",
+            "size": "3.7",
+          },
+          "id": "2",
+          "isRemovable": true,
+          "isSelectable": false,
+          "progress": 0.5,
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={true}
+      hasTableSwipeActions={false}
+      interactionType="hover"
+      isSelected={false}
+      key="3"
+      lastRow={false}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "test.pdf",
+            "fileType": "PDF",
+            "size": "2.2",
+          },
+          "id": "3",
+          "isSelectable": true,
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
+    <Memo(TableRow)
+      columns={
+        Array [
+          Object {
+            "alignment": "left",
+            "content": [Function],
+            "name": "fileName",
+            "size": "auto",
+            "title": "file name",
+          },
+          Object {
+            "alignment": "right",
+            "content": [Function],
+            "name": "createAt",
+            "size": "shrink",
+            "title": "created at",
+          },
+        ]
+      }
+      expandedSwipeCellRow={null}
+      hasLeftAction={true}
+      hasTableSwipeActions={false}
+      interactionType="hover"
+      isSelected={false}
+      key="4"
+      lastRow={true}
+      row={
+        Object {
+          "actions": Array [
+            Object {
+              "icon": "link",
+              "onClick": [Function],
+              "tooltipText": "Copy Link",
+              "type": "solid",
+            },
+            Object {
+              "icon": "pencil-alt",
+              "onClick": [Function],
+              "tooltipText": "Rename",
+              "type": "solid",
+            },
+            Object {
+              "icon": "file-download",
+              "onClick": [Function],
+              "tooltipText": "Download",
+              "type": "solid",
+            },
+            Object {
+              "icon": "trash",
+              "onClick": [Function],
+              "tooltipText": "Delete",
+              "type": "solid",
+            },
+          ],
+          "data": Object {
+            "createAt": "05/01/2018",
+            "fileName": "test1.pdf",
+            "fileType": "PDF",
+            "size": "1.5",
+          },
+          "id": "4",
+          "isSelectable": true,
+        }
+      }
+      setExpandedSwipeCellRow={[Function]}
+      toggleSelected={[Function]}
+    />
   </styled.table>
 </styled.div>
 `;
@@ -286,7 +784,7 @@ exports[`<Table /> should render an empty table 1`] = `
 >
   <styled.table>
     <styled.thead>
-      <TableHeader
+      <Memo(TableHeader)
         columns={
           Array [
             Object {
@@ -311,8 +809,8 @@ exports[`<Table /> should render an empty table 1`] = `
         hasTableSwipeActions={false}
         isEmpty={true}
         onSortChange={[MockFunction]}
-        selectedAll="false"
-        setSelectedAll={[Function]}
+        selectAllTableCheckboxInputValue="false"
+        setSelectAllTableCheckboxInputValue={[Function]}
         sort={
           Object {
             "createAt": "ascending",
@@ -320,21 +818,15 @@ exports[`<Table /> should render an empty table 1`] = `
         }
       />
     </styled.thead>
-    <TransitionGroup
-      childFactory={[Function]}
-      className="table-rows"
-      component="tbody"
-    >
-      <styled.tr>
-        <styled.td
-          colSpan={2}
-        >
-          <div>
-            empty
-          </div>
-        </styled.td>
-      </styled.tr>
-    </TransitionGroup>
+    <styled.tr>
+      <styled.td
+        colSpan={2}
+      >
+        <div>
+          empty
+        </div>
+      </styled.td>
+    </styled.tr>
   </styled.table>
 </styled.div>
 `;

--- a/src/domain/Tables/Table/services/helper.ts
+++ b/src/domain/Tables/Table/services/helper.ts
@@ -1,21 +1,26 @@
 import { clamp } from 'lodash'
 import { useEffect, useRef } from 'react'
 
-import { Props, Variables } from '../../../../common'
+import { Variables } from '../../../../common'
 import {
   FontAwesomeIconButton,
   IFontAwesomeIconButtonProps
 } from '../../../Buttons/FontAwesomeIconButton/FontAwesomeIconButton'
-import { TableCheckboxInputValue } from '../subcomponents/TableCheckboxInput'
-import { IColumnSorts, IRowProps, ISelectedRows, ITableProps, Table } from '../Table'
+import {
+  ColumnSortDirection,
+  IColumnSorts,
+  IRowProps,
+  ISelectedRows,
+  TableCheckboxInputValue
+} from './types'
 
 const usePrevious = <T extends {}>(value: T): T => {
-  const ref = useRef<T>()
+  const ref = useRef<T>(value)
   useEffect(() => {
     ref.current = value
   }, [value])
 
-  return ref.current as T
+  return ref.current
 }
 
 const getUpdatedAllSelectableRows = <T extends {}>(rows: Array<IRowProps<T>>, selectedRows: ISelectedRows) => (
@@ -65,7 +70,7 @@ const handleSortButtonClicked = (name: string, hasSortEnabled: boolean, sort?: I
   if (sort && onSortChange && hasSortEnabled) {
     onSortChange({
       ...sort,
-      [name]: sort[name] === Table.ColumnSortDirection.Descending ? Table.ColumnSortDirection.Ascending : Table.ColumnSortDirection.Descending
+      [name]: sort[name] === ColumnSortDirection.Descending ? ColumnSortDirection.Ascending : ColumnSortDirection.Descending
     })
   }
 }
@@ -73,13 +78,13 @@ const handleSortButtonClicked = (name: string, hasSortEnabled: boolean, sort?: I
 const handleHeaderTitleClicked = (name: string, setHasHeaderHovered: (value: boolean) => void, hasSortEnabled: boolean, sort?: IColumnSorts, onSortChange?: (value: IColumnSorts) => void) => () => {
   if (sort && onSortChange && hasSortEnabled) {
     let newSort = {
-      [name]: Table.ColumnSortDirection.Ascending
+      [name]: ColumnSortDirection.Ascending
     }
 
     if (sort[name]) {
       newSort = {
         ...sort,
-        [name]: sort[name] === Table.ColumnSortDirection.Descending ? Table.ColumnSortDirection.Ascending : Table.ColumnSortDirection.Descending
+        [name]: sort[name] === ColumnSortDirection.Descending ? ColumnSortDirection.Ascending : ColumnSortDirection.Descending
       }
     }
     setHasHeaderHovered(false)
@@ -87,13 +92,13 @@ const handleHeaderTitleClicked = (name: string, setHasHeaderHovered: (value: boo
   }
 }
 
-const getSortButtonDirection = (hasHeaderHovered: boolean, currentSortDirection?: Table.ColumnSortDirection) => {
+const getSortButtonDirection = (hasHeaderHovered: boolean, currentSortDirection?: ColumnSortDirection) => {
   if (hasHeaderHovered) {
     if (currentSortDirection) {
-      return currentSortDirection === Table.ColumnSortDirection.Descending ? Table.ColumnSortDirection.Ascending : Table.ColumnSortDirection.Descending
+      return currentSortDirection === ColumnSortDirection.Descending ? ColumnSortDirection.Ascending : ColumnSortDirection.Descending
     }
 
-    return Table.ColumnSortDirection.Ascending
+    return ColumnSortDirection.Ascending
   }
 
   return currentSortDirection
@@ -107,70 +112,11 @@ const handleRemoveButtonClick = (data: any, onRowRemove?: (data: any) => void) =
   }
 }
 
-const handleTableRowCheckboxInputChange = (id: string, selectedRows: ISelectedRows, setSelectedRows: (value: ISelectedRows) => void) => (value: TableCheckboxInputValue) => {
-  const newValue = {
-    ...selectedRows,
-    [id]: value === TableCheckboxInputValue.True
-  }
-  setSelectedRows(newValue)
-}
-
-const handleTableCellClicked = <T extends {}>(
-  id: string,
-  row: IRowProps<T>,
-  selectedRows: ISelectedRows,
-  setSelectedRows: (value: ISelectedRows) => void,
-  setHasHovered: (value: boolean) => void,
-  handleSwipeAction?: () => void,
-  isSelectable?: boolean,
-  onClick?: (data: any) => void
-) => () => {
-  if (isSelectable) {
-    const newValue = {
-      ...selectedRows,
-      [id]: !selectedRows[id]
-    }
-    setSelectedRows(newValue)
-  }
-
-  if (onClick) {
-    onClick(row.data)
-  }
-
-  if (handleSwipeAction) {
-    handleSwipeAction()
-  }
-
-  setHasHovered(false)
-}
-
 const getIconButtonWidth = (actions: IFontAwesomeIconButtonProps[]) => (
   actions.reduce((totalWidth: number, action) => {
     return totalWidth + (action.size === FontAwesomeIconButton.Size.Large ? Variables.Spacing.s3XLarge : Variables.Spacing.sXLarge)
   }, 0)
 )
-
-const getRowTransitionOpacity = (state?: 'entering' | 'entered' | 'exiting' | 'exited') => {
-  switch (state) {
-    case 'entering':
-    case 'entered':
-      return 1
-    case 'exiting':
-    case 'exited':
-    default:
-      return 0
-  }
-}
-
-const validateProps = <T>(props: ITableProps<T>) => {
-  if (props.hasLeftAction && props.interactionType === Table.InteractionType.Swipe) {
-    throw new Error('Having left actions is not compatible with swipe interaction')
-  }
-
-  if (props.onSortChange && !props.sort) {
-    throw new Error('You must provide a sort for onSortChange to work')
-  }
-}
 
 export {
   usePrevious,
@@ -182,9 +128,5 @@ export {
   getSortButtonDirection,
   parsedProgressToPercentage,
   handleRemoveButtonClick,
-  handleTableRowCheckboxInputChange,
-  handleTableCellClicked,
-  getIconButtonWidth,
-  getRowTransitionOpacity,
-  validateProps
+  getIconButtonWidth
 }

--- a/src/domain/Tables/Table/services/helper.ts
+++ b/src/domain/Tables/Table/services/helper.ts
@@ -7,7 +7,7 @@ import {
   IFontAwesomeIconButtonProps
 } from '../../../Buttons/FontAwesomeIconButton/FontAwesomeIconButton'
 import { TableCheckboxInputValue } from '../subcomponents/TableCheckboxInput'
-import { IColumnSorts, IRowProps, ISelectedRows, Table } from '../Table'
+import { IColumnSorts, IRowProps, ISelectedRows, ITableProps, Table } from '../Table'
 
 const usePrevious = <T extends {}>(value: T): T => {
   const ref = useRef<T>()
@@ -162,6 +162,16 @@ const getRowTransitionOpacity = (state?: 'entering' | 'entered' | 'exiting' | 'e
   }
 }
 
+const validateProps = <T>(props: ITableProps<T>) => {
+  if (props.hasLeftAction && props.interactionType === Table.InteractionType.Swipe) {
+    throw new Error('Having left actions is not compatible with swipe interaction')
+  }
+
+  if (props.onSortChange && !props.sort) {
+    throw new Error('You must provide a sort for onSortChange to work')
+  }
+}
+
 export {
   usePrevious,
   getUpdatedAllSelectableRows,
@@ -175,5 +185,6 @@ export {
   handleTableRowCheckboxInputChange,
   handleTableCellClicked,
   getIconButtonWidth,
-  getRowTransitionOpacity
+  getRowTransitionOpacity,
+  validateProps
 }

--- a/src/domain/Tables/Table/services/style.ts
+++ b/src/domain/Tables/Table/services/style.ts
@@ -4,9 +4,12 @@ import { Props, Variables } from '../../../../common'
 import { FontAwesomeIcon } from '../../../Icons/FontAwesomeIcon'
 import { styleForMargins } from '../../../Spacers/services/margins'
 import { TableCheckboxInputValue } from '../subcomponents/TableCheckboxInput'
-import { Table } from '../Table'
 import { TableRowVariant, variantOptions } from './colors'
-import {getRowTransitionOpacity} from './helper'
+import {
+  ColumnAlignment,
+  ColumnSize,
+  ColumnSortDirection
+} from './types'
 
 interface IStyledTableCheckboxInputProps {
   labelValue: TableCheckboxInputValue
@@ -29,11 +32,6 @@ interface IStyledRowProps {
   hasProgressBar?: boolean
   hideBottomBorder?: boolean
   hasTransition?: boolean
-  transitionState?: 'entering' | 'entered' | 'exiting' | 'exited'
-}
-
-interface IStyledProgressBarRowProps {
-  transitionState?: 'entering' | 'entered' | 'exiting' | 'exited'
 }
 
 interface IStyledSwipeActionsProps {
@@ -51,22 +49,22 @@ interface IStyledProgressBarProps {
 }
 
 interface IStyledHeaderCellProps {
-  size?: Table.ColumnSize
-  alignment?: Table.ColumnAlignment
+  size?: ColumnSize
+  alignment?: ColumnAlignment
   isLastColumn?: boolean
   isFirstColumn?: boolean
 }
 
 interface IStyledDataCellProps {
-  alignment?: Table.ColumnAlignment
+  alignment?: ColumnAlignment
   isLastColumn?: boolean
   isFirstColumn?: boolean
   hasProgressBar?: boolean
 }
 
 interface IStyledSortButtonProps {
-  sort?: Table.ColumnSortDirection
-  alignment: Table.ColumnAlignment
+  sort?: ColumnSortDirection
+  alignment: ColumnAlignment
 }
 
 const StyledTHead = styled.thead`
@@ -90,7 +88,7 @@ const StyledTable = styled.table`
 `
 
 const StyledHeaderCellWithHeaderSize = styled.th`
-  padding:  ${Variables.Spacing.sSmall}px ${Variables.Spacing.sMedium}px;
+  padding: ${Variables.Spacing.sSmall}px ${Variables.Spacing.sMedium}px;
 `
 
 const StyledHeaderCellContent = styled.div`
@@ -110,12 +108,12 @@ const StyledHeaderCell = styled.th`
       padding-left: ${Variables.Spacing.sMedium}px;
   `}
 
-  ${(props: IStyledHeaderCellProps) => props.size === Table.ColumnSize.Auto && css`
+  ${(props: IStyledHeaderCellProps) => props.size === ColumnSize.Auto && css`
       width: 100%;
       max-width: 0;
   `}
 
-  ${(props: IStyledHeaderCellProps) => props.alignment === Table.ColumnAlignment.Right && css`
+  ${(props: IStyledHeaderCellProps) => props.alignment === ColumnAlignment.Right && css`
       text-align: right;
   `}
 `
@@ -129,6 +127,7 @@ const StyledHeaderLeftCell = styled.th`
 const StyledSwipeActionsCell = styled.td`
   position: relative;
   padding: 0;
+  width: 0;
 `
 
 const StyledSwipeActionsButtonWrapper = styled.div`
@@ -165,18 +164,12 @@ const StyledSwipeActions = styled.div`
 const StyledProgressBarRow = styled.tr`
   border-bottom: 1px solid ${Variables.Color.n250};
   background: ${Variables.Color.n100};
-
-  ${(props: IStyledProgressBarRowProps) => css`
-      opacity: ${getRowTransitionOpacity(props.transitionState)};
-      transition: opacity 500ms ease-in-out;
-  `}
 `
 const StyledEmptyStateRow = styled.tr`
   border: none;
 `
 
 const StyledRow = styled.tr`
-  opacity: 1;
   white-space: nowrap;
   border: none;
   border-bottom: 1px solid ${Variables.Color.n250};
@@ -214,15 +207,6 @@ const StyledRow = styled.tr`
       border: none;
       border-bottom: 0;
   `}
-
-  ${(props: IStyledRowProps) => props.hasTransition && css`
-      opacity: 0;
-  `}
-
-  ${(props: IStyledRowProps) => props.transitionState && css`
-      opacity: ${getRowTransitionOpacity(props.transitionState)};
-      transition: opacity 500ms ease-in-out;
-  `}
 `
 
 const StyledDataCellChangeAnimation = keyframes`
@@ -242,7 +226,7 @@ const StyledDataCell = styled.td`
   animation-duration: 500ms;
   animation-timing-function: ease-in;
 
-  ${(props: IStyledDataCellProps) => props.alignment === Table.ColumnAlignment.Right && css`
+  ${(props: IStyledDataCellProps) => props.alignment === ColumnAlignment.Right && css`
       text-align: right;
   `}
 
@@ -296,11 +280,11 @@ const StyledSortButton = styled.div`
   margin: 0;
   transition: transform .2s ease-out, display .2s ease-out;
 
-  ${(props: IStyledSortButtonProps) => props.alignment === Table.ColumnAlignment.Right && css`
+  ${(props: IStyledSortButtonProps) => props.alignment === ColumnAlignment.Right && css`
       margin-right: ${Variables.Spacing.sXSmall}px;
   `}
 
-  ${(props: IStyledSortButtonProps) => props.alignment === Table.ColumnAlignment.Left && css`
+  ${(props: IStyledSortButtonProps) => props.alignment === ColumnAlignment.Left && css`
       margin-left: ${Variables.Spacing.sXSmall}px;
   `}
 
@@ -308,7 +292,7 @@ const StyledSortButton = styled.div`
       display: inline-block;
   `}
 
-  ${(props: IStyledSortButtonProps) => props.sort === Table.ColumnSortDirection.Descending && css`
+  ${(props: IStyledSortButtonProps) => props.sort === ColumnSortDirection.Descending && css`
       transform: rotate(180deg);
   `}
 `

--- a/src/domain/Tables/Table/services/style.ts
+++ b/src/domain/Tables/Table/services/style.ts
@@ -272,7 +272,7 @@ const StyledProgressBar = styled.div`
 `
 
 const StyledEmptyStateCell = styled.td`
-  padding: ${Variables.Spacing.s3XLarge}px;
+  padding: 0;
 `
 
 const StyledSortButton = styled.div`

--- a/src/domain/Tables/Table/services/types.ts
+++ b/src/domain/Tables/Table/services/types.ts
@@ -1,0 +1,70 @@
+import { IFontAwesomeIconButtonProps } from '../../../../domain/Buttons/FontAwesomeIconButton/FontAwesomeIconButton'
+import { TableRowVariant } from './colors'
+
+enum ColumnAlignment {
+  Left = 'left',
+  Right = 'right'
+}
+
+enum ColumnSize {
+  Auto = 'auto',
+  Shrink = 'shrink'
+}
+enum ColumnSortDirection {
+  Descending = 'descending',
+  Ascending = 'ascending'
+}
+
+enum InteractionType {
+  Hover = 'hover',
+  Swipe = 'swipe'
+}
+
+enum TableCheckboxInputValue {
+  True = 'true',
+  False = 'false',
+  PartialTrue = 'partialTrue'
+}
+
+interface ISelectedRows {
+  [rowId: string]: boolean
+}
+
+interface IColumnSorts {
+  [columnName: string]: ColumnSortDirection
+}
+
+interface IRowProps <T> {
+  id: string
+  isSelectable?: boolean
+  isRemovable?: boolean
+  tooltipText?: string
+  progress?: number
+  variant?: TableRowVariant
+  data: T
+  contentOverride?: (rowData: T) => JSX.Element[] | JSX.Element
+  onClick?: (rowData: T) => void
+  actions?: IFontAwesomeIconButtonProps[]
+}
+
+interface IColumnProps <T> {
+  name: string
+  title?: string
+  size: ColumnSize
+  headerSize?: ColumnSize
+  content: (rowData: T) => JSX.Element
+  alignment?: ColumnAlignment
+  tooltipText?: (rowData: T) => string
+}
+
+export {
+  ColumnAlignment,
+  ColumnSize,
+  ColumnSortDirection,
+  InteractionType,
+  TableCheckboxInputValue,
+  ISelectedRows,
+  IColumnSorts,
+  IRowProps,
+  IColumnProps
+}

--- a/src/domain/Tables/Table/subcomponents/ActionIconButtonGroup.tsx
+++ b/src/domain/Tables/Table/subcomponents/ActionIconButtonGroup.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import { FontAwesomeIconButton, IFontAwesomeIconButtonProps } from '../../../../domain/Buttons/FontAwesomeIconButton/FontAwesomeIconButton'
+import { StyledFontAwesomeIconButtonWrapper } from '../services/style'
+
+const getActionsIconButtonGroup = (actions?: IFontAwesomeIconButtonProps[], name?: string) => {
+  if (actions) {
+    return (
+      <div>
+        {actions.map((actionProps, index) => (
+          <StyledFontAwesomeIconButtonWrapper key={`actions-${name}-${index}`}>
+            <FontAwesomeIconButton {...actionProps}/>
+          </StyledFontAwesomeIconButtonWrapper>
+        ))}
+      </div>
+    )
+  }
+
+  return null
+}
+
+export {
+  getActionsIconButtonGroup
+}

--- a/src/domain/Tables/Table/subcomponents/TableCheckboxInput.tsx
+++ b/src/domain/Tables/Table/subcomponents/TableCheckboxInput.tsx
@@ -6,12 +6,7 @@ import {
   StyledTableCheckboxInput,
   StyledTableCheckboxLabel
 } from '../services/style'
-
-enum TableCheckboxInputValue {
-  True = 'true',
-  False = 'false',
-  PartialTrue = 'partialTrue'
-}
+import { TableCheckboxInputValue } from '../services/types'
 
 interface ITableCheckboxInputProps {
   /** Name of the input */
@@ -45,28 +40,16 @@ const getIcon = (value: TableCheckboxInputValue) => {
 const TableCheckboxInput: React.FC<ITableCheckboxInputProps> = ({
   name,
   onChange,
-  value= TableCheckboxInputValue.False,
+  value = TableCheckboxInputValue.False,
   isDisabled,
   autoFocus,
   componentContext,
   hasStyledOnRowHovered = true
 }) => {
-  const [currentValue, setCurrentValue] = useState<TableCheckboxInputValue>(value)
-  useEffect(() => {
-    if (onChange) {
-      onChange(currentValue)
-    }
-  }, [currentValue])
-  useEffect(() => {
-    setCurrentValue(value)
-  }, [value])
   const handleChange = () => {
-    if (currentValue === TableCheckboxInputValue.False) {
-      setCurrentValue(TableCheckboxInputValue.True)
-    } else {
-      setCurrentValue(TableCheckboxInputValue.False)
+    if (onChange) {
+      onChange((value === TableCheckboxInputValue.True) ? TableCheckboxInputValue.False : TableCheckboxInputValue.True)
     }
-
   }
 
   return (
@@ -75,21 +58,21 @@ const TableCheckboxInput: React.FC<ITableCheckboxInputProps> = ({
         id={name}
         name={name}
         type='checkbox'
-        labelValue={currentValue}
-        value={currentValue === TableCheckboxInputValue.True ? 1 : 0}
+        labelValue={value}
+        value={value === TableCheckboxInputValue.True ? 1 : 0}
         onChange={handleChange}
         disabled={isDisabled}
         autoFocus={autoFocus}
         data-component-type={Props.ComponentType.CheckboxInput}
         data-component-context={componentContext}
-        checked={currentValue === TableCheckboxInputValue.True}
+        checked={value === TableCheckboxInputValue.True}
       />
       <StyledTableCheckboxLabel
         htmlFor={name}
-        value={currentValue}
+        value={value}
         hasStyledOnRowHovered={hasStyledOnRowHovered}
       >
-        {getIcon(currentValue)}
+        {getIcon(value)}
       </StyledTableCheckboxLabel>
     </>
   )

--- a/src/domain/Tables/Table/subcomponents/TableHeader.tsx
+++ b/src/domain/Tables/Table/subcomponents/TableHeader.tsx
@@ -21,17 +21,20 @@ import {
   StyledSortButton
 } from '../services/style'
 import {
+  ColumnAlignment,
+  ColumnSize,
   IColumnProps,
-  IColumnSorts,
-  Table,
+  IColumnSorts
+} from '../services/types'
+import {
   getActionsIconButtonGroup
-} from '../Table'
+} from './ActionIconButtonGroup'
 import { TableCheckboxInput, TableCheckboxInputValue } from './TableCheckboxInput'
 
 interface ITableHeaderProps <T> {
   columns: Array<IColumnProps<T>>
-  selectedAll: TableCheckboxInputValue
-  setSelectedAll: (value: TableCheckboxInputValue) => void
+  selectAllTableCheckboxInputValue: TableCheckboxInputValue
+  setSelectAllTableCheckboxInputValue: (value: TableCheckboxInputValue) => void
   bulkActions?: IFontAwesomeIconButtonProps[]
   hasLeftAction: boolean
   hasBulkAction: boolean
@@ -54,7 +57,7 @@ const TableHeaderCellContent = <T extends {}>(props: ITableHeaderCellContentProp
   const {
     name,
     title,
-    alignment = Table.ColumnAlignment.Left
+    alignment = ColumnAlignment.Left
   } = column
 
   const [hasHeaderHovered, setHasHeaderHovered] = useState<boolean>(false)
@@ -80,13 +83,13 @@ const TableHeaderCellContent = <T extends {}>(props: ITableHeaderCellContentProp
   if (title) {
     return (
       <StyledHeaderCellContent>
-        {alignment === Table.ColumnAlignment.Right && sortButton}
+        {alignment === ColumnAlignment.Right && sortButton}
         <span onMouseEnter={setHeaderHoveredTrue} onMouseLeave={setHeaderHoveredFalse}>
             <Text weight={Variables.FontWeight.fwSemiBold}>
               {hasSortEnabled ? headerTitleLink : title}
             </Text>
           </span>
-        {alignment === Table.ColumnAlignment.Left && sortButton}
+        {alignment === ColumnAlignment.Left && sortButton}
       </StyledHeaderCellContent>
     )
   }
@@ -115,8 +118,8 @@ const getHeaderCells = <T extends {}>(
 
               return ({
                 displayType: 'flex',
-                flexHorizontalAlignment: (column.alignment && column.alignment === Table.ColumnAlignment.Right) ? GridLayout.HorizontalAlignment.Right : GridLayout.HorizontalAlignment.Left,
-                size: (size === Table.ColumnSize.Shrink) ? 'shrink' : 'auto',
+                flexHorizontalAlignment: (column.alignment && column.alignment === ColumnAlignment.Right) ? GridLayout.HorizontalAlignment.Right : GridLayout.HorizontalAlignment.Left,
+                size: (size === ColumnSize.Shrink) ? 'shrink' : 'auto',
                 content: <div><TableHeaderCellContent<T> column={column} sort={sort} onSortChange={onSortChange} hasSortEnabled={hasSortEnabled}/></div>
               })
             })
@@ -131,7 +134,7 @@ const getHeaderCells = <T extends {}>(
       const {
         name,
         size,
-        alignment = Table.ColumnAlignment.Left
+        alignment = ColumnAlignment.Left
       } =  column
 
       const isLastColumn = index === columns.length - 1
@@ -162,15 +165,13 @@ const TableHeader = <T extends {}>(props: ITableHeaderProps<T>) => {
     sort,
     onSortChange,
     hasTableSwipeActions,
-    selectedAll,
-    setSelectedAll,
+    selectAllTableCheckboxInputValue,
+    setSelectAllTableCheckboxInputValue,
     bulkActions,
     hasBulkAction,
     isEmpty,
     hasSortEnabled
   } = props
-
-  const setSelectedAllTableCheckboxInputValue = useCallback((value) => setSelectedAll(value), [setSelectedAll])
 
   return (
     <StyledRow variant={TableRowVariant.Neutral}>
@@ -180,8 +181,8 @@ const TableHeader = <T extends {}>(props: ITableHeaderProps<T>) => {
             <StyledHeaderLeftCell>
               <TableCheckboxInput
                 name='selectAll'
-                value={selectedAll}
-                onChange={setSelectedAllTableCheckboxInputValue}
+                value={selectAllTableCheckboxInputValue}
+                onChange={setSelectAllTableCheckboxInputValue}
                 hasStyledOnRowHovered={false}
               />
             </StyledHeaderLeftCell>
@@ -196,6 +197,9 @@ const TableHeader = <T extends {}>(props: ITableHeaderProps<T>) => {
   )
 }
 
+// Purposefully not deep comparison as columns and sort are both memoisable in other applications
+const MemoTableHeader: typeof TableHeader = React.memo(TableHeader) as any
+
 export {
-  TableHeader
+  MemoTableHeader as TableHeader
 }

--- a/src/domain/Tables/Table/subcomponents/TableRowDataCell.tsx
+++ b/src/domain/Tables/Table/subcomponents/TableRowDataCell.tsx
@@ -1,0 +1,97 @@
+import React, { useCallback } from 'react'
+
+import { TooltipPopover } from '../../../Popovers/TooltipPopover'
+import { TooltipPopoverVariant } from '../../../Popovers/TooltipPopover/TooltipPopover'
+import { StyledDataCell } from '../services/style'
+import { IColumnProps, IRowProps } from '../services/types'
+
+interface ITableRowDataCellProps <T> {
+  column: IColumnProps<T>
+  row: IRowProps<T>
+  hasProgressBar: boolean
+  isLastColumn: boolean
+  hasTableSwipeActions: boolean
+  hasSwipeActions: boolean
+  toggleSelected: (row: IRowProps<T>) => void
+  setHasHovered: (value: boolean) => void
+  handleSwipeAction?: () => void
+  isFirstColumn: boolean
+  children: JSX.Element
+}
+
+const TableCellTooltip: React.FC<{tooltipText: string}> = ({ tooltipText, children}) => {
+  const toggleComponent = ({ openMenu, closeMenu, toggleComponentRef, ariaProps }: any) => (
+    <span
+      onMouseEnter={openMenu}
+      onMouseLeave={closeMenu}
+      ref={toggleComponentRef}
+      {...ariaProps}
+    >
+      {children}
+    </span>
+  )
+
+  return (
+    <TooltipPopover
+      variant={TooltipPopoverVariant.Dark}
+      toggleComponent={toggleComponent}
+    >
+      {tooltipText}
+    </TooltipPopover>
+  )
+}
+
+const TableRowDataCell = <T extends {}>(props: ITableRowDataCellProps<T>) => {
+  const {
+    hasProgressBar,
+    isLastColumn,
+    hasTableSwipeActions,
+    hasSwipeActions,
+    column,
+    row,
+    toggleSelected,
+    setHasHovered,
+    handleSwipeAction,
+    isFirstColumn,
+    children
+  } = props
+
+  const {
+    isSelectable = false,
+    onClick,
+    id
+  } = row
+
+  const handleTableCellClicked = useCallback(() => {
+    if (isSelectable) {
+      toggleSelected(row)
+    }
+
+    if (onClick) {
+      onClick(row.data)
+    }
+
+    if (handleSwipeAction) {
+      handleSwipeAction()
+    }
+
+    setHasHovered(false)
+  }, [isSelectable, toggleSelected, row, onClick, handleSwipeAction, setHasHovered])
+
+  return (
+    <StyledDataCell
+      hasProgressBar={hasProgressBar}
+      colSpan={(isLastColumn && hasTableSwipeActions && !hasSwipeActions) ? 2 : undefined}
+      alignment={column.alignment}
+      onClick={handleTableCellClicked}
+      isLastColumn={isLastColumn}
+      isFirstColumn={isFirstColumn}
+    >
+      {column.tooltipText ? <TableCellTooltip tooltipText={column.tooltipText(row.data)}>{children}</TableCellTooltip> : children}
+    </StyledDataCell>
+  )
+}
+
+export {
+  TableRowDataCell
+}


### PR DESCRIPTION
**PATCH**
- [x] #773 [INT-11024] Make table component compatible with empty state. @MichaelDevenish
- [x] #771 [INT-11011] Refactor &lt;Table&gt; component to fix rerender issues @seanmanson
- [x] #774 [INT-10368]Add StatusDotColor property in Avatar class @briancjkim
- [x] #772 [INT-11033]Add back zindex on card and groupcard for access button  to be clickable @briancjkim
- [x] #770 [INT-11005] Validate props passed into table. @MichaelDevenish

**Technical Improvements**
- [x] #653 [INT-7611] Use slash params @callum-p

