### PR TITLE
[INT-12161] Remove unusable key prop and fix GridChild typing in gridlayout

### DIFF
--- a/src/domain/Layouts/GridLayout/subcomponents/Cell.tsx
+++ b/src/domain/Layouts/GridLayout/subcomponents/Cell.tsx
@@ -16,7 +16,6 @@ import {
 type CellDisplayType = 'block' | 'flex'
 
 interface ICellProps {
-  key?: string | number
   gridColumns?: number
   size?: CellSize | IStyledCellSizes
   offset?: CellOffset | IStyledCellOffsets


### PR DESCRIPTION
 - `key` prop would never work because you can't have props called that in React. It was only useful for the now-removed animations feature and has been removed. Marking this as PATCH as existing code wouldn't have worked for this anyways
 - `GridChild` typing made it impossible to have an element and an array of elements as children. Making it recursive fixes this.

INT-12161

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [x]  New and updated components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
