### PR TITLE
Prevent PaginationButtons from submitting forms

### DIFF
--- a/src/domain/Paginators/PaginationButtons/PaginationButtons.tsx
+++ b/src/domain/Paginators/PaginationButtons/PaginationButtons.tsx
@@ -183,6 +183,7 @@ export class PaginationButtons extends React.PureComponent<IPaginationButtonsPro
         key={`pagination-${pageNumber}`}
         isCurrent={currentPage === pageNumber}
         onClick={this.changePage(pageNumber)}
+        type='button'
       >
         {pageNumber}
       </StylePaginationButton>

--- a/src/domain/Paginators/PaginationButtons/__snapshots__/PaginationButtons.test.tsx.snap
+++ b/src/domain/Paginators/PaginationButtons/__snapshots__/PaginationButtons.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`<PaginationButtons /> should render the pagination buttons 1`] = `
     isCurrent={true}
     key="pagination-1"
     onClick={[Function]}
+    type="button"
   >
     1
   </styled.button>
@@ -29,6 +30,7 @@ exports[`<PaginationButtons /> should render the pagination buttons 1`] = `
     isCurrent={false}
     key="pagination-2"
     onClick={[Function]}
+    type="button"
   >
     2
   </styled.button>
@@ -36,6 +38,7 @@ exports[`<PaginationButtons /> should render the pagination buttons 1`] = `
     isCurrent={false}
     key="pagination-3"
     onClick={[Function]}
+    type="button"
   >
     3
   </styled.button>
@@ -43,6 +46,7 @@ exports[`<PaginationButtons /> should render the pagination buttons 1`] = `
     isCurrent={false}
     key="pagination-4"
     onClick={[Function]}
+    type="button"
   >
     4
   </styled.button>
@@ -50,6 +54,7 @@ exports[`<PaginationButtons /> should render the pagination buttons 1`] = `
     isCurrent={false}
     key="pagination-5"
     onClick={[Function]}
+    type="button"
   >
     5
   </styled.button>
@@ -62,6 +67,7 @@ exports[`<PaginationButtons /> should render the pagination buttons 1`] = `
     isCurrent={false}
     key="pagination-10"
     onClick={[Function]}
+    type="button"
   >
     10
   </styled.button>
@@ -112,6 +118,7 @@ exports[`<PaginationButtons /> should render the pagination buttons with margin 
     isCurrent={true}
     key="pagination-1"
     onClick={[Function]}
+    type="button"
   >
     1
   </styled.button>
@@ -119,6 +126,7 @@ exports[`<PaginationButtons /> should render the pagination buttons with margin 
     isCurrent={false}
     key="pagination-2"
     onClick={[Function]}
+    type="button"
   >
     2
   </styled.button>
@@ -126,6 +134,7 @@ exports[`<PaginationButtons /> should render the pagination buttons with margin 
     isCurrent={false}
     key="pagination-3"
     onClick={[Function]}
+    type="button"
   >
     3
   </styled.button>
@@ -133,6 +142,7 @@ exports[`<PaginationButtons /> should render the pagination buttons with margin 
     isCurrent={false}
     key="pagination-4"
     onClick={[Function]}
+    type="button"
   >
     4
   </styled.button>
@@ -140,6 +150,7 @@ exports[`<PaginationButtons /> should render the pagination buttons with margin 
     isCurrent={false}
     key="pagination-5"
     onClick={[Function]}
+    type="button"
   >
     5
   </styled.button>
@@ -152,6 +163,7 @@ exports[`<PaginationButtons /> should render the pagination buttons with margin 
     isCurrent={false}
     key="pagination-10"
     onClick={[Function]}
+    type="button"
   >
     10
   </styled.button>


### PR DESCRIPTION
It seems like a lot of places is using `PaginationButtons`, but I assume none of them relies on it to submit a form or something~

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
