### PR TITLE
[INT-13011] Update tooltip popover default toggle component to be span instead of button

### DIFF
--- a/src/domain/Formats/Record/__snapshots__/Record.test.tsx.snap
+++ b/src/domain/Formats/Record/__snapshots__/Record.test.tsx.snap
@@ -1859,14 +1859,13 @@ exports[`<Record /> should render a Record with a Tooltip 1`] = `
                     <span
                       className="c2"
                     >
-                      <button
+                      <span
                         aria-expanded={false}
                         aria-haspopup={true}
                         className="popoverTrigger"
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                         role="button"
-                        type="button"
                       >
                         <FontAwesomeIcon
                           color="#424F5C"
@@ -1974,7 +1973,7 @@ exports[`<Record /> should render a Record with a Tooltip 1`] = `
                             </styled.i>
                           </Icon>
                         </FontAwesomeIcon>
-                      </button>
+                      </span>
                     </span>
                   </StyledComponent>
                 </styled.span>
@@ -1998,12 +1997,11 @@ exports[`<Record /> should render a Record with a Tooltip 1`] = `
   font-size: 1rem;
 }
 
-<button
+<span
                         aria-expanded="false"
                         aria-haspopup="true"
                         class="popoverTrigger"
                         role="button"
-                        type="button"
                       >
                         <i
                           aria-hidden="true"
@@ -2011,7 +2009,7 @@ exports[`<Record /> should render a Record with a Tooltip 1`] = `
                           color="#424F5C"
                           data-component-type="icon"
                         />
-                      </button>,
+                      </span>,
                     }
                   }
                   popoverAnchorPosition="auto"

--- a/src/domain/Popovers/TooltipPopover/TooltipPopover.tsx
+++ b/src/domain/Popovers/TooltipPopover/TooltipPopover.tsx
@@ -59,16 +59,15 @@ class TooltipPopover extends React.Component<ITooltipPopoverProps, ITooltipPopov
   public static defaultProps: Partial<ITooltipPopoverProps> = {
     variant: TooltipPopoverVariant.Neutral,
     toggleComponent: ({ openMenu, closeMenu, toggleComponentRef, ariaProps }) => (
-      <button
+      <span
         className={style.popoverTrigger}
-        type='button'
         onMouseEnter={openMenu}
         onMouseLeave={closeMenu}
         ref={toggleComponentRef}
         {...ariaProps}
       >
         <FontAwesomeIcon type='regular' icon='question-circle' color={Variables.Color.n700} />
-      </button>
+      </span>
     )
   }
 

--- a/src/domain/Popovers/TooltipPopover/__snapshots__/TooltipPopover.test.tsx.snap
+++ b/src/domain/Popovers/TooltipPopover/__snapshots__/TooltipPopover.test.tsx.snap
@@ -37,21 +37,20 @@ exports[`<TooltipPopover /> Render a popover using a custom trigger should match
 exports[`<TooltipPopover /> Simple popover behaviour should match the snapshot 1`] = `
 <Fragment>
   <styled.span>
-    <button
+    <span
       aria-expanded={false}
       aria-haspopup={true}
       className="popoverTrigger"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       role="button"
-      type="button"
     >
       <Memo(FontAwesomeIcon)
         color="#424F5C"
         icon="question-circle"
         type="regular"
       />
-    </button>
+    </span>
   </styled.span>
   <Popover
     animationType="tooltip"
@@ -77,21 +76,20 @@ exports[`<TooltipPopover /> Simple popover behaviour should match the snapshot 1
 exports[`<TooltipPopover /> dark style popover behaviour should match the snapshot 1`] = `
 <Fragment>
   <styled.span>
-    <button
+    <span
       aria-expanded={false}
       aria-haspopup={true}
       className="popoverTrigger"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       role="button"
-      type="button"
     >
       <Memo(FontAwesomeIcon)
         color="#424F5C"
         icon="question-circle"
         type="regular"
       />
-    </button>
+    </span>
   </styled.span>
   <Popover
     animationType="tooltip"


### PR DESCRIPTION

INT-13011

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [x]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [x]  You have requested a cross-team review on this component so everyone knows it exists
