### PR TITLE
[INT-13879] Fix modal close button for mobile screens using Safari

### DIFF
--- a/src/domain/Modals/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/domain/Modals/Modal/__snapshots__/Modal.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`<Modal /> should render a hidden modal 1`] = `
     will-change: scroll-position;
     left: 12px;
     top: 16px !important;
+    width: 8px;
   }
 
   .c0 .modal.subcomponent-modal-style .modal-close-button::before {
@@ -283,6 +284,8 @@ exports[`<Modal /> should render a hidden modal 1`] = `
           will-change: scroll-position;
           left: 12px;
           top: 16px !important;
+          /* This is required to fix the element width in safari while using left */
+          width: 8px;
 
           &::before {
             font-family: 'Font Awesome 5 Pro';
@@ -585,6 +588,7 @@ exports[`<Modal /> should render a hidden modal 1`] = `
     will-change: scroll-position;
     left: 12px;
     top: 16px !important;
+    width: 8px;
   }
 
   .c0 .modal.subcomponent-modal-style .modal-close-button::before {

--- a/src/domain/Modals/Modal/style.tsx
+++ b/src/domain/Modals/Modal/style.tsx
@@ -104,6 +104,8 @@ const StyledReactModal = styled(ReactModalAdapter)`
           will-change: scroll-position;
           left: 12px;
           top: 16px !important;
+          /* This is required to fix the element width in safari while using left */
+          width: 8px;
 
           &::before {
             font-family: 'Font Awesome 5 Pro';


### PR DESCRIPTION
INT-13879

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
