### PR TITLE
[INT-13879] Increase hit area of Modal close button for mobile screens

### DIFF
--- a/src/domain/Modals/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/domain/Modals/Modal/__snapshots__/Modal.test.tsx.snap
@@ -103,9 +103,10 @@ exports[`<Modal /> should render a hidden modal 1`] = `
   .c0 .modal.subcomponent-modal-style .modal-close-button {
     position: fixed;
     will-change: scroll-position;
-    left: 12px;
-    top: 16px !important;
-    width: 8px;
+    left: 0;
+    top: 0;
+    height: 48px;
+    width: 48px;
   }
 
   .c0 .modal.subcomponent-modal-style .modal-close-button::before {
@@ -282,10 +283,10 @@ exports[`<Modal /> should render a hidden modal 1`] = `
               "px) {
           position: fixed;
           will-change: scroll-position;
-          left: 12px;
-          top: 16px !important;
-          /* This is required to fix the element width in safari while using left */
-          width: 8px;
+          left: 0;
+          top: 0;
+          height: 48px;
+          width: 48px;
 
           &::before {
             font-family: 'Font Awesome 5 Pro';
@@ -586,9 +587,10 @@ exports[`<Modal /> should render a hidden modal 1`] = `
   .c0 .modal.subcomponent-modal-style .modal-close-button {
     position: fixed;
     will-change: scroll-position;
-    left: 12px;
-    top: 16px !important;
-    width: 8px;
+    left: 0;
+    top: 0;
+    height: 48px;
+    width: 48px;
   }
 
   .c0 .modal.subcomponent-modal-style .modal-close-button::before {

--- a/src/domain/Modals/Modal/style.tsx
+++ b/src/domain/Modals/Modal/style.tsx
@@ -102,10 +102,10 @@ const StyledReactModal = styled(ReactModalAdapter)`
         @media only screen and (max-width: ${breakpointTablet}px) {
           position: fixed;
           will-change: scroll-position;
-          left: 12px;
-          top: 16px !important;
-          /* This is required to fix the element width in safari while using left */
-          width: 8px;
+          left: 0;
+          top: 0;
+          height: 48px;
+          width: 48px;
 
           &::before {
             font-family: 'Font Awesome 5 Pro';

--- a/src/domain/Modals/Modal/subcomponents/__snapshots__/Header.test.tsx.snap
+++ b/src/domain/Modals/Modal/subcomponents/__snapshots__/Header.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`<Header /> should render modal header 1`] = `
     -moz-letter-spacing: -.02em;
     -ms-letter-spacing: -.02em;
     letter-spacing: -.02em;
-    margin-left: 24px;
+    margin-left: 38px;
   }
 }
 
@@ -149,7 +149,7 @@ exports[`<Header /> should render modal header 1`] = `
           letter-spacing: -.02em;
         ",
                     "
-      margin-left: 24px;
+      margin-left: 38px;
   }
 ",
                   ],

--- a/src/domain/Modals/Modal/subcomponents/style.ts
+++ b/src/domain/Modals/Modal/subcomponents/style.ts
@@ -28,7 +28,7 @@ const StyledModalHeaderHeading = styled.div`
 
   @media only screen and (max-width: ${Variables.Breakpoint.breakpointTablet}px) {
       ${styleForTypographyType(Props.TypographyType.Heading)}
-      margin-left: 24px;
+      margin-left: 38px;
   }
 `
 


### PR DESCRIPTION
INT-13879

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
