### PR TITLE
[INT-14020][INT-14024] Allow <Table> tooltips to be optional and give them a forced maxwidth

### DIFF
--- a/src/domain/Tables/Table/Table.examples.md
+++ b/src/domain/Tables/Table/Table.examples.md
@@ -63,14 +63,17 @@ const rowActions = ([
           name: 'fileName',
           title: 'File Name',
           size: 'auto',
-          content: (data)=> <Text>{data.fileName}</Text>,
-          alignment: 'left'
+          content: (data) => <Text>{data.fileName}</Text>,
+          alignment: 'left',
+          tooltipText: (row) => (row.fileName === 'test1.pdf') ?
+            'This row has a long stretch of text used for its tooltip. This should only exist for the second row, and should break into multiple lines.' :
+            null
       },
       {
           name: 'createAt',
           title: 'Date uploaded',
           size: 'shrink',
-          content: (data)=> <Text>{data.createAt}</Text>,
+          content: (data) => <Text>{data.createAt}</Text>,
           alignment: 'right'
       }
   ]}
@@ -287,7 +290,7 @@ const successRowToNormal = {
     onSelectedRowChange = {(dataSet) => {setState({selectedDataSet:dataSet}); console.log(dataSet)}}
     rows={state.rows}
     sort={state.sort}
-    hasSortEnabled={true} 
+    hasSortEnabled={true}
     onSortChange={(sort) => setState({sort})}
     columns={[
       {
@@ -413,7 +416,7 @@ const successRowContentOverride = (
       id: '4',
       data: {fileName: 'test1.pdf', createAt: '05/01/2018', size: '1.5', fileType: 'PDF'},
       isSelectable: true,
-      actions: rowActions 
+      actions: rowActions
       }
   ]}
   sort={state.sort}

--- a/src/domain/Tables/Table/services/types.ts
+++ b/src/domain/Tables/Table/services/types.ts
@@ -54,7 +54,7 @@ interface IColumnProps <T> {
   headerSize?: ColumnSize
   content: (rowData: T) => JSX.Element
   alignment?: ColumnAlignment
-  tooltipText?: (rowData: T) => string
+  tooltipText?: (rowData: T) => string | null | undefined
 }
 
 export {

--- a/src/domain/Tables/Table/subcomponents/TableRowDataCell.tsx
+++ b/src/domain/Tables/Table/subcomponents/TableRowDataCell.tsx
@@ -35,6 +35,7 @@ const TableCellTooltip: React.FC<{tooltipText: string}> = ({ tooltipText, childr
     <TooltipPopover
       variant={TooltipPopoverVariant.Dark}
       toggleComponent={toggleComponent}
+      width={300}
     >
       {tooltipText}
     </TooltipPopover>
@@ -77,6 +78,8 @@ const TableRowDataCell = <T extends {}>(props: ITableRowDataCellProps<T>) => {
     setHasHovered(false)
   }, [isSelectable, toggleSelected, row, onClick, handleSwipeAction, setHasHovered])
 
+  const tooltipText = column.tooltipText?.(row.data)
+
   return (
     <StyledDataCell
       size={column.size}
@@ -87,7 +90,7 @@ const TableRowDataCell = <T extends {}>(props: ITableRowDataCellProps<T>) => {
       isLastColumn={isLastColumn}
       isFirstColumn={isFirstColumn}
     >
-      {column.tooltipText ? <TableCellTooltip tooltipText={column.tooltipText(row.data)}>{children}</TableCellTooltip> : children}
+      {tooltipText ? <TableCellTooltip tooltipText={tooltipText}>{children}</TableCellTooltip> : children}
     </StyledDataCell>
   )
 }


### PR DESCRIPTION

![Screenshot from 2020-08-18 10-23-21](https://user-images.githubusercontent.com/26075658/90456882-6ad7be80-e13d-11ea-89f3-08772ea221b4.png)
INT-14020
INT-14024

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [x]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [x]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [x]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
