### PR TITLE
[INT-13163] Default TooltipPopover max-width to 300px

### DIFF
--- a/src/domain/Buttons/FontAwesomeIconButton/__snapshots__/FontAwesomeIconButton.test.tsx.snap
+++ b/src/domain/Buttons/FontAwesomeIconButton/__snapshots__/FontAwesomeIconButton.test.tsx.snap
@@ -500,6 +500,7 @@ exports[`<FontAwesomeIconButton /> should render an icon button 1`] = `
     data-component-type="font_awesome_icon_button"
     toggleComponent={[Function]}
     variant="dark"
+    width={300}
   >
     <styled.span>
       <StyledComponent

--- a/src/domain/Formats/HintWrapper/__snapshots__/HintWrapper.test.tsx.snap
+++ b/src/domain/Formats/HintWrapper/__snapshots__/HintWrapper.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`<HintWrapper /> should render a popover hint wrapper 1`] = `
 <TooltipPopover
   toggleComponent={[Function]}
   variant="neutral"
+  width={300}
 >
   Never trust a cat
 </TooltipPopover>

--- a/src/domain/Formats/Record/__snapshots__/Record.test.tsx.snap
+++ b/src/domain/Formats/Record/__snapshots__/Record.test.tsx.snap
@@ -414,6 +414,7 @@ exports[`<Record /> should render a Record and tooltip with a custom tooltip and
               <TooltipPopover
                 toggleComponent={[Function]}
                 variant="neutral"
+                width={300}
               >
                 <styled.span>
                   <StyledComponent
@@ -1824,6 +1825,7 @@ exports[`<Record /> should render a Record with a Tooltip 1`] = `
               <TooltipPopover
                 toggleComponent={[Function]}
                 variant="neutral"
+                width={300}
               >
                 <styled.span>
                   <StyledComponent

--- a/src/domain/Popovers/TooltipPopover/TooltipPopover.tsx
+++ b/src/domain/Popovers/TooltipPopover/TooltipPopover.tsx
@@ -57,6 +57,7 @@ interface ITooltipPopoverProps {
 class TooltipPopover extends React.Component<ITooltipPopoverProps, ITooltipPopoverMenuState> {
   public static Variant = TooltipPopoverVariant
   public static defaultProps: Partial<ITooltipPopoverProps> = {
+    width: 300,
     variant: TooltipPopoverVariant.Neutral,
     toggleComponent: ({ openMenu, closeMenu, toggleComponentRef, ariaProps }) => (
       <span

--- a/src/domain/Popovers/TooltipPopover/__snapshots__/TooltipPopover.test.tsx.snap
+++ b/src/domain/Popovers/TooltipPopover/__snapshots__/TooltipPopover.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`<TooltipPopover /> Render a popover using a custom trigger should match
   >
     <styled.div
       variant="neutral"
+      width={300}
     >
       Triggered Customly
     </styled.div>
@@ -66,6 +67,7 @@ exports[`<TooltipPopover /> Simple popover behaviour should match the snapshot 1
   >
     <styled.div
       variant="neutral"
+      width={300}
     >
       Simple Popover
     </styled.div>
@@ -105,6 +107,7 @@ exports[`<TooltipPopover /> dark style popover behaviour should match the snapsh
   >
     <styled.div
       variant="dark"
+      width={300}
     >
       dark Popover
     </styled.div>

--- a/src/domain/Popovers/TooltipPopover/style.ts
+++ b/src/domain/Popovers/TooltipPopover/style.ts
@@ -9,7 +9,7 @@ interface IStyledToggleComponentWrapper {
 }
 
 interface IStyledTooltipContentProps {
-  width?: number
+  width: number
   variant: TooltipPopoverVariant
 }
 
@@ -21,7 +21,7 @@ const StyledTooltipContent = styled.div`
   width: max-content;
 
   ${styleForLineBreakText()}
-  ${(props: IStyledTooltipContentProps) => props.width && css`max-width: ${props.width}px`}
+  ${(props: IStyledTooltipContentProps) => css`max-width: ${props.width}px`}
 
   ${(props: IStyledTooltipContentProps) => {
 


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
