### PR TITLE
[KIKI-14405] Allow cards to overflow past the 999px magic number height

### DIFF
--- a/src/domain/Cards/Card/style.ts
+++ b/src/domain/Cards/Card/style.ts
@@ -148,6 +148,7 @@ const StyledExtraContent = styled.div`
   height: auto;
   max-height: 0;
   overflow: hidden;
+  overflow-y: auto;
   transition: max-height .5s;
   ${cardCollpaseAnimation}
   border: 1px solid ${Variables.Color.n250};


### PR DESCRIPTION
intellihr/engineering/guilds/front-end#14405

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
