### PR TITLE
Add type props to enable password input

### DIFF
--- a/src/domain/Inputs/TextInput/TextInput.examples.md
+++ b/src/domain/Inputs/TextInput/TextInput.examples.md
@@ -133,3 +133,15 @@ initialState = { value: 'I have a custom width 500px' };
 />
 ```
 
+#### Password Input
+
+```jsx
+initialState = { textValue: '1234567890' };
+
+<TextInput
+  type='password'
+  value={state.textValue}
+  onChange={(value) => {setState({textValue: value})}}
+/>
+```
+

--- a/src/domain/Inputs/TextInput/TextInput.test.tsx
+++ b/src/domain/Inputs/TextInput/TextInput.test.tsx
@@ -153,4 +153,17 @@ describe('<TextInput />', () => {
 
     expect(wrapper).toMatchSnapshot()
   })
+
+  it(`should render an password input`, () => {
+    const wrapper = shallow(
+      <TextInput
+        type='password'
+        value='test'
+        name='test'
+        onChange={dummyFunction}
+      />
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
 })

--- a/src/domain/Inputs/TextInput/TextInput.tsx
+++ b/src/domain/Inputs/TextInput/TextInput.tsx
@@ -24,6 +24,8 @@ interface ITextInputProps {
   onChange?: (value: string) => void
   /** Value of the input */
   value?: string | number
+  /** Type of the input */
+  type?: 'text' | 'password'
   /** If true, sets input to disabled state */
   isDisabled?: boolean
   /** Icon to display in the input box */
@@ -130,6 +132,7 @@ class TextInput extends React.PureComponent<ITextInputProps> {
       width,
       componentContext,
       margins,
+      type,
       'aria-label': label
     } = this.props
 
@@ -137,7 +140,7 @@ class TextInput extends React.PureComponent<ITextInputProps> {
       <StyledTextInput
         id={id || name}
         name={name}
-        type='text'
+        type={type ? type : 'text'}
         value={value}
         onChange={this.handleChange}
         onKeyDown={handleKeyDown}

--- a/src/domain/Inputs/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/domain/Inputs/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -53,6 +53,19 @@ exports[`<TextInput /> should render an invalid text input 1`] = `
 />
 `;
 
+exports[`<TextInput /> should render an password input 1`] = `
+<styled.input
+  className="input "
+  data-component-type="text_input"
+  id="test"
+  name="test"
+  onChange={[Function]}
+  onFocus={[Function]}
+  type="password"
+  value="test"
+/>
+`;
+
 exports[`<TextInput /> should render an text input 1`] = `
 <styled.input
   className="input "


### PR DESCRIPTION
INT-14666

**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
