### PR TITLE
update menuItem to  receive openInNewTab prop and pass it down to its children component

### DIFF
--- a/src/domain/Menus/Menu/Menu.examples.md
+++ b/src/domain/Menus/Menu/Menu.examples.md
@@ -149,3 +149,17 @@ import { FontAwesomeIcon } from '@Domain/Icons';
   </Menu.Item>
 </Menu>
 ```
+#### Menu item opening in new tab
+
+```jsx
+import { FontAwesomeIcon } from '@Domain/Icons';
+
+<Menu>
+  <Menu.Item
+    icon={<FontAwesomeIcon type='solid' icon='star' />}
+    label='Item 1'
+    href='https://www.google.com/'
+    openInNewTab={true}
+  />
+</Menu>
+```

--- a/src/domain/Menus/Menu/MenuItem/MenuItem.tsx
+++ b/src/domain/Menus/Menu/MenuItem/MenuItem.tsx
@@ -18,7 +18,8 @@ const MenuItem: React.FC<IMenuItemProps> = (
     icon,
     isActive,
     isLoading,
-    label
+    label,
+    openInNewTab = false
   }) => {
   const [open, setOpen] = useState(isOpen || false)
   const onToggle = useCallback((type: IToggleType) => {
@@ -42,6 +43,7 @@ const MenuItem: React.FC<IMenuItemProps> = (
             anchorComponentProps={anchorComponentProps}
             icon={icon}
             isLoading={isLoading}
+            openInNewTab={openInNewTab}
           />
         }
       >
@@ -59,6 +61,7 @@ const MenuItem: React.FC<IMenuItemProps> = (
       anchorComponentProps={anchorComponentProps}
       icon={icon}
       isLoading={isLoading}
+      openInNewTab={openInNewTab}
     />
   )
 }
@@ -71,6 +74,7 @@ const MemoMenuItem = React.memo(MenuItem,(prevProps, nextProps) => {
     nextProps.isActive === prevProps.isActive &&
     nextProps.isOpen === prevProps.isOpen &&
     prevProps.children === nextProps.children &&
+    prevProps.openInNewTab === nextProps.openInNewTab &&
     isEqual(prevProps.handleSizeChange, nextProps.handleSizeChange) &&
     (prevProps.anchorComponentProps === nextProps.anchorComponentProps || isEqual(prevProps.anchorComponentProps, nextProps.anchorComponentProps))
 })

--- a/src/domain/Menus/Menu/MenuItem/MenuItemContent/MenuItemContent.tsx
+++ b/src/domain/Menus/Menu/MenuItem/MenuItemContent/MenuItemContent.tsx
@@ -16,13 +16,15 @@ const MenuItemContent: React.FC<IMenuItemContent> = ({
         icon,
         label,
         isLoading,
-        isOpen
+        isOpen,
+        openInNewTab
       }) => {
   return (
     <StyledMenuItem
       isActive={isActive}
       href={href}
       anchorComponentProps={anchorComponentProps}
+      openInNewTab={openInNewTab}
     >
       {icon && (
         <StyledIcon isActive={isActive}>

--- a/src/domain/Menus/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
+++ b/src/domain/Menus/Menu/MenuItem/__snapshots__/MenuItem.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<MenuItem /> should render a a menu item with a link 1`] = `
 <MenuItemContent
   href="www.google.com"
   label="Test menu item"
+  openInNewTab={false}
 />
 `;
 
@@ -21,6 +22,7 @@ exports[`<MenuItem /> should render a menu item as a submenu if it has children 
       }
       isOpen={false}
       label="Father"
+      openInNewTab={false}
     />
   }
 >
@@ -56,6 +58,7 @@ exports[`<MenuItem /> should render a menu item with Icon 1`] = `
     />
   }
   label="Test menu item"
+  openInNewTab={false}
 />
 `;
 
@@ -64,6 +67,7 @@ exports[`<MenuItem /> should render a menu item with active state 1`] = `
   href="www.google.com"
   isActive={true}
   label="Test menu item"
+  openInNewTab={false}
 />
 `;
 
@@ -77,11 +81,13 @@ exports[`<MenuItem /> should render a menu item with loading state 1`] = `
   }
   isLoading={true}
   label="Test menu item"
+  openInNewTab={false}
 />
 `;
 
 exports[`<MenuItem /> should render a simple menu item 1`] = `
 <MenuItemContent
   label="Test menu item"
+  openInNewTab={false}
 />
 `;

--- a/src/domain/Menus/Menu/MenuItem/interfaces.ts
+++ b/src/domain/Menus/Menu/MenuItem/interfaces.ts
@@ -17,11 +17,13 @@ interface IMenuItemProps<TAnchorProps extends Record<string, any> = Record<strin
   handleSizeChange?: () => void
   /** The properties to be passed on to the custom anchor component if provided in the Provider */
   anchorComponentProps?: TAnchorProps
+  /** Open a new tab. Default is false */
+  openInNewTab?: boolean
   /** Children components */
   children?: React.ReactNode
 }
 
-type IMenuItemContent = Pick<IMenuItemProps, 'isActive' | 'isOpen' | 'href' | 'anchorComponentProps' | 'icon' | 'label' | 'isLoading'>
+type IMenuItemContent = Pick<IMenuItemProps, 'isActive' | 'isOpen' | 'href' | 'anchorComponentProps' | 'icon' | 'label' | 'isLoading'| 'openInNewTab'>
 
 export {
   IMenuItemProps,


### PR DESCRIPTION
**The following MUST be checked prior to approval. If not relevant to your PR, remove the line from your description.**
- [ ]  The `styleguide.config.js` has been updated to show examples/new functionality for the component
- [ ]  Test Coverage for any new or updated functionality
- [ ]  New and updated components have been tested locally in lapis and SPA and work as expected
- [ ]  This PR has been tagged with PATCH, MINOR, or MAJOR.
- [ ]  The component has data-component-type and data-component-context attributes following the standard
- [ ]  You have requested a cross-team review on this component so everyone knows it exists
